### PR TITLE
Remove non available camera

### DIFF
--- a/docs/source/tutorials/1_Get_Started.ipynb
+++ b/docs/source/tutorials/1_Get_Started.ipynb
@@ -46,11 +46,11 @@
    "outputs": [],
    "source": [
     "env = gym.make('myoElbowPose1D6MRandom-v0')\n",
-    "print('List of cameras available',env.sim.model.camera_names)\n",
+    "print('List of cameras available', env.sim.model.camera_names)\n",
     "env.reset()\n",
     "frames = []\n",
     "for _ in range(100):\n",
-    "    frame = env.sim.render(width=400, height=400,mode='offscreen', camera_name='hand_bottom')\n",
+    "    frame = env.sim.render(width=400, height=400,mode='offscreen')\n",
     "    frames.append(frame[::-1,:,:])\n",
     "    env.step(env.action_space.sample()) # take a random action\n",
     "env.close()\n",


### PR DESCRIPTION
Fix #12 

As there is only one available camera, it can be removed for the environment setup. This fixes the example 1.