### PR TITLE
Feature/mjx utils

### DIFF
--- a/myosuite/envs/myo/fatigue_jax.py
+++ b/myosuite/envs/myo/fatigue_jax.py
@@ -1,0 +1,204 @@
+import jax.numpy as jp
+import jax.random as jrandom
+import mujoco
+from typing import Dict, Tuple, Any
+from jax import tree_util
+import numpy as np
+
+# Constants for floating-point precision
+_FLOAT_EPS = jp.finfo(jp.float32).eps
+_EPS4 = _FLOAT_EPS * 4.0
+
+
+class CumulativeFatigue:
+    """
+    JAX implementation of the 3CC-r muscle fatigue model
+    Adapted from https://dl.acm.org/doi/pdf/10.1145/3313831.3376701
+    Based on implementation from Aleksi Ikkala and Florian Fischer
+    """
+
+    def __init__(self, mj_model, frame_skip=1):
+        # Get muscle actuator indices
+        muscle_act_ind = mj_model.actuator_dyntype == mujoco.mjtDyn.mjDYN_MUSCLE
+        # Convert to concrete integer value
+        self.na = int(np.sum(muscle_act_ind))  # Use numpy here since we're in __init__
+
+        # Dynamic arrays (will be included in tree_flatten children)
+        self.MA = jp.zeros(self.na, dtype=jp.float32)  # Muscle Active
+        self.MR = jp.ones(self.na, dtype=jp.float32)  # Muscle Resting
+        self.MF = jp.zeros(self.na, dtype=jp.float32)  # Muscle Fatigue
+        self.TL = jp.zeros(self.na, dtype=jp.float32)  # Target Load
+
+        # Parameters (will be included in tree_flatten children)
+        self.F = jp.array(0.00912, dtype=jp.float32)  # Fatigue coefficient
+        self.R = jp.array(0.1 * 0.00094, dtype=jp.float32)  # Recovery coefficient
+        self.r = jp.array(10 * 15, dtype=jp.float32)  # Recovery multiplier
+        self.dt = jp.array(mj_model.opt.timestep * frame_skip, dtype=jp.float32)
+
+        # Get muscle parameters
+        self.tauact = jp.array(
+            [
+                mj_model.actuator_dynprm[i][0]
+                for i in range(len(muscle_act_ind))
+                if muscle_act_ind[i]
+            ],
+            dtype=jp.float32,
+        )
+        self.taudeact = jp.array(
+            [
+                mj_model.actuator_dynprm[i][1]
+                for i in range(len(muscle_act_ind))
+                if muscle_act_ind[i]
+            ],
+            dtype=jp.float32,
+        )
+
+    def _tree_flatten(self) -> Tuple[Tuple[Any, ...], Dict]:
+        """Flatten the class into children and auxiliary data"""
+        # Dynamic values (arrays that change during computation)
+        children = (
+            self.MA,
+            self.MR,
+            self.MF,
+            self.TL,
+            self.F,
+            self.R,
+            self.r,
+            self.dt,
+            self.tauact,
+            self.taudeact,
+        )
+
+        # Static values
+        aux_data = {"na": self.na}
+        return (children, aux_data)
+
+    @classmethod
+    def _tree_unflatten(cls, aux_data, children):
+        """Reconstruct class from flattened data"""
+        obj = cls.__new__(cls)  # Create new instance without __init__
+
+        # Restore dynamic values
+        (
+            obj.MA,
+            obj.MR,
+            obj.MF,
+            obj.TL,
+            obj.F,
+            obj.R,
+            obj.r,
+            obj.dt,
+            obj.tauact,
+            obj.taudeact,
+        ) = children
+
+        # Restore static values
+        obj.na = aux_data["na"]
+        return obj
+
+    # @jax.jit
+    def compute_act(self, act):
+        """
+        Compute muscle activation considering fatigue
+
+        Args:
+            act: Target activation levels
+
+        Returns:
+            tuple: (MA, MR, MF) states
+        """
+        # Set target load
+        self.TL = jp.array(act, dtype=jp.float32)
+
+        # Calculate effective time constants
+        LD = 1 / self.tauact * (0.5 + 1.5 * self.MA)
+        LR = (0.5 + 1.5 * self.MA) / self.taudeact
+
+        # Calculate C(t) - transfer rate between MR and MA
+        C = jp.zeros_like(self.MA)
+
+        # Case 1: MA < TL and MR > (TL - MA)
+        mask1 = (self.MA < self.TL) & (self.MR > (self.TL - self.MA))
+        C = jp.where(mask1, LD * (self.TL - self.MA), C)
+
+        # Case 2: MA < TL and MR <= (TL - MA)
+        mask2 = (self.MA < self.TL) & (self.MR <= (self.TL - self.MA))
+        C = jp.where(mask2, LD * self.MR, C)
+
+        # Case 3: MA >= TL
+        mask3 = self.MA >= self.TL
+        C = jp.where(mask3, LR * (self.TL - self.MA), C)
+
+        # Calculate recovery rate
+        rR = jp.where(self.MA >= self.TL, self.r * self.R, self.R)
+
+        # Clip C(t) to ensure states remain between 0 and 1
+        C_min = jp.maximum(
+            -self.MA / self.dt + self.F * self.MA,
+            (self.MR - 1) / self.dt + rR * self.MF,
+        )
+        C_max = jp.minimum(
+            (1 - self.MA) / self.dt + self.F * self.MA, self.MR / self.dt + rR * self.MF
+        )
+        C = jp.clip(C, C_min, C_max)
+
+        # Update states
+        dMA = (C - self.F * self.MA) * self.dt
+        dMR = (-C + rR * self.MF) * self.dt
+        dMF = (self.F * self.MA - rR * self.MF) * self.dt
+
+        self.MA = self.MA + dMA
+        self.MR = self.MR + dMR
+        self.MF = self.MF + dMF
+
+        return self.MA, self.MR, self.MF
+
+    # @jax.jit
+    def get_effort(self):
+        """Calculate effort as norm of difference between actual and target activation"""
+        return jp.linalg.norm(self.MA - self.TL)
+
+    def reset(self, fatigue_reset_vec=None, fatigue_reset_random=False, key=None):
+        """Reset fatigue states"""
+        if fatigue_reset_random:
+            assert (
+                fatigue_reset_vec is None
+            ), "Cannot use fatigue_reset_vec if fatigue_reset_random=True"
+            key1, key2 = jrandom.split(key)
+            non_fatigued_muscles = jrandom.uniform(key1, (self.na,))
+            active_percentage = jrandom.uniform(key2, (self.na,))
+            self.MA = non_fatigued_muscles * active_percentage
+            self.MR = non_fatigued_muscles * (1 - active_percentage)
+            self.MF = 1 - non_fatigued_muscles
+        else:
+            if fatigue_reset_vec is not None:
+                assert (
+                    len(fatigue_reset_vec) == self.na
+                ), f"Invalid length of fatigue vector (expected {self.na}, got {len(fatigue_reset_vec)})"
+                self.MF = jp.array(fatigue_reset_vec, dtype=jp.float32)
+                self.MR = 1 - self.MF
+                self.MA = jp.zeros(self.na, dtype=jp.float32)
+            else:
+                self.MA = jp.zeros(self.na, dtype=jp.float32)
+                self.MR = jp.ones(self.na, dtype=jp.float32)
+                self.MF = jp.zeros(self.na, dtype=jp.float32)
+
+    def set_FatigueCoefficient(self, F):
+        """Set Fatigue coefficient"""
+        self.F = jp.array(F, dtype=jp.float32)
+
+    def set_RecoveryCoefficient(self, R):
+        """Set Recovery coefficient"""
+        self.R = jp.array(R, dtype=jp.float32)
+
+    def set_RecoveryMultiplier(self, r):
+        """Set Recovery time multiplier"""
+        self.r = jp.array(r, dtype=jp.float32)
+
+
+# Register the class as a PyTree
+tree_util.register_pytree_node(
+    CumulativeFatigue,
+    CumulativeFatigue._tree_flatten,
+    CumulativeFatigue._tree_unflatten,
+)

--- a/myosuite/logger/reference_motion_jax.py
+++ b/myosuite/logger/reference_motion_jax.py
@@ -1,0 +1,335 @@
+import enum
+from typing import Union
+import collections
+from jax import numpy as jp
+import jax
+import jax.random as jrandom
+import pickle
+
+# Time precision to use. Avoids rounding/resolution errors during comparisons
+_TIME_PRECISION = 4
+
+# Reference structure
+ReferenceStruct = collections.namedtuple(
+    "ReferenceStruct",
+    [
+        "time",  # float(N)
+        "robot",  # shape(N, n_robot_jnt) ==> robot trajectory
+        "robot_vel",  # shape(N, n_robot_jnt) ==> robot velocity
+        "object",  # shape(M, n_objects_jnt) ==> object trajectory
+        "robot_init",  # shape(n_objects_jnt) ==> initial robot pose (can be different from robot(0,n_robot_jnt))
+        "object_init",  # shape(n_objects_jnt) ==> initial object (can be different from object(0,n_object_jnt))
+    ],
+)
+
+
+# Reference type
+class ReferenceType(enum.Enum):
+    """Reference types"""
+
+    FIXED = 0
+    RANDOM = 1
+    TRACK = 2
+
+
+# Reference motion
+class ReferenceMotion:
+    def __init__(
+        self, reference_data: Union[str, dict], motion_extrapolation: bool = False
+    ):
+        """
+        Reference Type
+            Fixed  :: N==1, M==1  :: input is <Fixed target dict>
+            Random :: N==2, M==2  :: input is <Randomization range dict> :: ind0:low_limit, ind1:high_limit
+            Track  :: N>2 or M>2  :: input as <Motion file to be tracked>
+        """
+        self.motion_extrapolation = motion_extrapolation
+
+        # load reference
+        self.reference = self.load(reference_data)
+        # check reference for format
+        self.check_format(self.reference)
+        self.reference["time"] = jp.around(
+            self.reference["time"], _TIME_PRECISION
+        )  # round to help with comparisons
+        robot_shape = (
+            self.reference["robot"].shape
+            if self.reference["robot"] is not None
+            else (0, 0)
+        )
+        object_shape = (
+            self.reference["object"].shape
+            if self.reference["object"] is not None
+            else (0, 0)
+        )
+        self.robot_dim = robot_shape[1]
+        self.object_dim = object_shape[1]
+
+        # identify type
+        if robot_shape[0] > 2 or object_shape[0] > 2:
+            self.type = ReferenceType.TRACK
+        elif robot_shape[0] == 2 or object_shape[0] == 2:
+            self.type = ReferenceType.RANDOM
+        elif robot_shape[0] == 1 or object_shape[0] == 1:
+            self.type = ReferenceType.FIXED
+        else:
+            raise ValueError("Reference values not per specs")
+
+        # identify length
+        self.robot_horizon = robot_shape[0]
+        self.object_horizon = object_shape[0]
+        self.horizon = max(robot_shape[0], object_shape[0])
+
+        # Add missing values
+        if self.type == ReferenceType.RANDOM:
+            # use mean postures from the randomization range
+            if "robot_init" not in self.reference.keys():
+                self.reference["robot_init"] = jp.mean(self.reference["robot"], axis=0)
+            if "object_init" not in self.reference.keys():
+                self.reference["object_init"] = jp.mean(self.reference["object"][0])
+        else:
+            # use first timeset
+            if "robot_init" not in self.reference.keys():
+                self.reference["robot_init"] = self.reference["robot"][0]
+            if "object_init" not in self.reference.keys():
+                self.reference["object_init"] = self.reference["object"][0]
+
+        # cache to help with finding index
+        self.index_cache = 0
+
+    def check_format(self, reference):
+        """
+        Check reference format
+        """
+        if reference["robot"] is not None:
+            assert (
+                reference["robot"].ndim == 2
+            ), "Check robot reference, must be shape(N, n_robot_jnt)"
+        if reference["object"] is not None:
+            assert (
+                reference["object"].ndim == 2
+            ), "Check object reference, must be shape(N, n_object_jnt)"
+        if reference["robot_init"] is not None:
+            assert (
+                reference["robot_init"].ndim == 1
+            ), "Check robot_init reference, must be shape(n_robot_jnt)"
+        if reference["robot"] is not None and reference["robot_init"] is not None:
+            assert (
+                reference["robot_init"].shape[0] == reference["robot"].shape[1]
+            ), "n_robot_jnt different between motion and init"
+        if reference["object_init"] is not None:
+            assert (
+                reference["object_init"].ndim == 1
+            ), "Check object_init reference, must be shape(n_object_jnt)"
+        if reference["object_init"] is not None and reference["object"] is not None:
+            assert (
+                reference["object_init"].shape[0] == reference["object"].shape[1]
+            ), "n_object_jnt different between motion and init"
+
+    def load(self, reference_data):
+        """
+        Load reference motion
+        """
+        if isinstance(reference_data, str):
+            if reference_data.endswith("npz"):
+                reference = {k: jp.array(v) for k, v in jp.load(reference_data).items()}
+            elif reference_data.endswith(("pkl", "pickle")):
+                with open(reference_data, "rb") as data:
+                    reference = pickle.load(data)
+        elif isinstance(reference_data, dict):
+            reference = reference_data.copy()
+        else:
+            raise TypeError("Unknown reference type")
+
+        # resolve values
+        assert "time" in reference.keys(), "Missing key (time) in reference"
+        reference.setdefault(
+            "robot_init", reference["robot"][0] if "robot" in reference else None
+        )
+        reference.setdefault(
+            "object_init", reference["object"][0] if "object" in reference else None
+        )
+
+        result = ReferenceStruct(
+            time=jp.array(reference["time"]),
+            robot=reference.get("robot"),
+            robot_vel=reference.get("robot_vel"),
+            object=reference.get("object"),
+            robot_init=reference["robot_init"],
+            object_init=reference["object_init"],
+        )._asdict()
+
+        return result
+
+    def find_timeslot_in_reference(self, time):
+        """
+        Find the timeslot interval for the provided time in the reference motion.
+        """
+        time = jp.around(time, _TIME_PRECISION)
+        
+        # Use jax.lax.cond to handle the conditional logic
+        def fixed_case(_):
+            return (0, 0)
+
+        def extrapolation_case(_):
+            return (self.horizon - 1, self.horizon - 1)
+
+        def normal_case(_):
+            # Use jax.lax.cond for conditional logic
+            def check_current_index(_):
+                return (self.index_cache, self.index_cache)
+
+            def check_next_index(_):
+                return (self.index_cache + 1, self.index_cache + 1)
+
+            def search_index(_):
+                new_index = jp.searchsorted(self.reference["time"], time, side="right") - 1
+                return jax.lax.cond(
+                    time == self.reference["time"][new_index],
+                    lambda _: (new_index, new_index),
+                    lambda _: (new_index, new_index + 1),
+                    operand=None
+                )
+
+            return jax.lax.cond(
+                time == self.reference["time"][self.index_cache],
+                check_current_index,
+                lambda _: jax.lax.cond(
+                    (self.index_cache < (self.horizon - 1)) & (time == self.reference["time"][self.index_cache + 1]),
+                    check_next_index,
+                    search_index,
+                    operand=None
+                ),
+                operand=None
+            )
+
+        # Use jax.lax.cond to handle the top-level conditional logic
+        return jax.lax.cond(
+            self.type == ReferenceType.FIXED,
+            fixed_case,
+            lambda _: jax.lax.cond(
+                self.motion_extrapolation & (time >= self.reference["time"][-1]),
+                extrapolation_case,
+                normal_case,
+                operand=None
+            ),
+            operand=None
+        )
+
+    def reset(self):
+        self.index_cache = 0
+
+    def get_init(self):
+        """Return the initial posture of the robot and the object."""
+        result = self.reference["robot_init"], self.reference["object_init"]
+
+        return result
+
+    def get_reference(self, time):
+        """
+        Return the reference at the given time, with linear interpolation if needed.
+        """
+        if self.type == ReferenceType.FIXED:
+            robot_ref = self.reference["robot"][0]
+            robot_vel_ref = self.reference["robot_vel"][0]
+            object_ref = self.reference["object"][0]
+        elif self.type == ReferenceType.RANDOM:
+            rng_key, rng1, rng2 = jrandom.split(jax.random.PRNGKey(0), 3)
+            robot_ref = jrandom.uniform(
+                rng1,
+                shape=self.reference["robot"][
+                    0, :
+                ].shape,  # Specify the shape explicitly
+                minval=self.reference["robot"][0, :],
+                maxval=self.reference["robot"][1, :],
+            )
+            robot_vel_ref = jrandom.uniform(
+                rng2,
+                shape=self.reference["robot_vel"][
+                    0, :
+                ].shape,  # Specify the shape explicitly
+                minval=self.reference["robot_vel"][0, :],
+                maxval=self.reference["robot_vel"][1, :],
+            )
+            object_ref = jrandom.uniform(
+                rng_key,
+                shape=self.reference["object"][0, :].shape,
+                minval=self.reference["object"][0, :],
+                maxval=self.reference["object"][1, :],
+            )
+        elif self.type == ReferenceType.TRACK:
+            ind, ind_next = self.find_timeslot_in_reference(time=time)
+            # Use jax.lax.cond to handle the conditional logic
+            def exact_frame_case(_):
+                # Exact frame[time] found for reference
+                robot_ref = (
+                    self.reference["robot"][ind]
+                    if self.robot_horizon > 1
+                    else self.reference["robot"][0]
+                )
+                robot_vel_ref = (
+                    None
+                    if self.reference["robot_vel"] is None
+                    else self.reference["robot_vel"][ind]
+                )
+                object_ref = (
+                    None
+                    if self.reference["object"] is None
+                    else self.reference["object"][ind]
+                )
+                return robot_ref, robot_vel_ref, object_ref
+
+            def interpolate_case(_):
+                # Linearly interpolate between frames to get references
+                blend = time - self.reference["time"][ind] / (
+                    self.reference["time"][ind_next] - self.reference["time"][ind]
+                )
+
+                # robot motion
+                if self.robot_horizon > 1:
+                    robot_ref = (1.0 - blend) ** self.reference["robot"][
+                        ind
+                    ] + blend * self.reference["robot"][ind_next]
+                    robot_vel_ref = (
+                        None
+                        if self.reference["robot_vel"] is None
+                        else (1.0 - blend) ** self.reference["robot_vel"][ind]
+                        + blend * self.reference["robot_vel"][ind_next]
+                    )
+                else:
+                    robot_ref = self.reference["robot"][0]
+                    robot_vel_ref = (
+                        None
+                        if self.reference["robot_vel"] is None
+                        else self.reference["robot_vel"][0]
+                    )
+                # object motion
+                if self.reference["object"] is None:
+                    object_ref = None
+                elif self.object_horizon > 1:
+                    object_ref = (1.0 - blend) * self.reference["object"][
+                        ind
+                    ] + blend * self.reference["object"][ind_next]
+                else:
+                    object_ref = self.reference["object"][0]
+
+                return robot_ref, robot_vel_ref, object_ref
+
+            robot_ref, robot_vel_ref, object_ref = jax.lax.cond(
+                ind == ind_next,
+                exact_frame_case,
+                interpolate_case,
+                operand=None
+            )
+
+        return ReferenceStruct(
+            time=time,
+            robot=robot_ref,
+            robot_vel=robot_vel_ref,
+            object=object_ref,
+            robot_init=self.reference["robot_init"],
+            object_init=self.reference["object_init"],
+        )
+
+    def __repr__(self) -> str:
+        return repr(self.reference)

--- a/myosuite/tests/mjx/test_fatigue.py
+++ b/myosuite/tests/mjx/test_fatigue.py
@@ -1,0 +1,254 @@
+import unittest
+import numpy as np
+import jax
+import jax.numpy as jp
+import mujoco
+from jax import tree_util
+
+from myosuite.envs.myo.fatigue import CumulativeFatigue as NumpyCumulativeFatigue
+from myosuite.envs.myo.fatigue_jax import CumulativeFatigue as JaxCumulativeFatigue
+
+# Configure JAX to use CPU for consistent testing
+jax.config.update("jax_platform_name", "cpu")
+
+
+class TestFatigue(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        """Set up test data and model"""
+        cls.model = mujoco.MjModel.from_xml_path(
+            "myosuite/simhive/myo_sim/finger/myofinger_v0.xml"
+        )
+        cls.frame_skip = 5
+        cls.test_act = np.array([0.5] * 5, dtype=np.float32)
+        cls.test_fatigue_vec = np.array([0.5] * 5, dtype=np.float32)
+
+    def test_pytree_structure(self):
+        """Test that the class works correctly as a PyTree"""
+        fatigue = JaxCumulativeFatigue(self.model, frame_skip=self.frame_skip)
+
+        # Test flattening and unflattening
+        flat, treedef = tree_util.tree_flatten(fatigue)
+        restored = tree_util.tree_unflatten(treedef, flat)
+
+        # Check that all attributes are preserved
+        np.testing.assert_allclose(restored.MA, fatigue.MA)
+        np.testing.assert_allclose(restored.MR, fatigue.MR)
+        np.testing.assert_allclose(restored.MF, fatigue.MF)
+        self.assertEqual(restored.na, fatigue.na)
+
+        # Test that the restored object works correctly
+        MA1, _, _ = fatigue.compute_act(self.test_act)
+        MA2, _, _ = restored.compute_act(self.test_act)
+        np.testing.assert_allclose(MA1, MA2)
+
+    def test_random_reset(self):
+        """Test random reset with explicit key handling"""
+        fatigue = JaxCumulativeFatigue(self.model, frame_skip=self.frame_skip)
+        key = jax.random.PRNGKey(0)
+
+        # Test random reset
+        fatigue.reset(key=key, fatigue_reset_random=True)
+
+        # Verify states sum to 1
+        total = fatigue.MA + fatigue.MR + fatigue.MF
+        np.testing.assert_allclose(total, jp.ones_like(total))
+
+        # Test deterministic behavior with same key
+        fatigue2 = JaxCumulativeFatigue(self.model, frame_skip=self.frame_skip)
+        fatigue2.reset(key=key, fatigue_reset_random=True)
+
+        np.testing.assert_allclose(fatigue.MA, fatigue2.MA)
+        np.testing.assert_allclose(fatigue.MR, fatigue2.MR)
+        np.testing.assert_allclose(fatigue.MF, fatigue2.MF)
+
+    def test_compute_act_vmap(self):
+        """Test that compute_act works with vmap"""
+        batch_size = 2
+        batch_acts = jp.stack([self.test_act] * batch_size)
+
+        # Define a batched computation using vmap and JIT
+        @jax.jit
+        def batch_compute(acts):
+            def single_compute(act):
+                fatigue = JaxCumulativeFatigue(self.model, frame_skip=self.frame_skip)
+                return fatigue.compute_act(act)
+
+            return jax.vmap(single_compute)(acts)
+
+        # Run batch computation
+        batch_MA, batch_MR, batch_MF = batch_compute(batch_acts)
+
+        # Verify shapes
+        self.assertEqual(batch_MA.shape, (batch_size, 5))
+        self.assertEqual(batch_MR.shape, (batch_size, 5))
+        self.assertEqual(batch_MF.shape, (batch_size, 5))
+
+        # Verify against sequential computation
+        for i in range(batch_size):
+            fatigue = JaxCumulativeFatigue(self.model, frame_skip=self.frame_skip)
+            MA, MR, MF = fatigue.compute_act(batch_acts[i])
+            np.testing.assert_allclose(MA, batch_MA[i])
+            np.testing.assert_allclose(MR, batch_MR[i])
+            np.testing.assert_allclose(MF, batch_MF[i])
+
+    def test_random_reset_vmap(self):
+        """Test that random reset works with vmap"""
+        batch_size = 3
+        key = jax.random.PRNGKey(0)
+        keys = jax.random.split(key, batch_size)
+
+        # Define batched reset function
+        @jax.jit
+        def batch_reset(keys):
+            def single_reset(key):
+                fatigue = JaxCumulativeFatigue(self.model, frame_skip=self.frame_skip)
+                fatigue.reset(key=key, fatigue_reset_random=True)
+                return fatigue.MA, fatigue.MR, fatigue.MF
+
+            return jax.vmap(single_reset)(keys)
+
+        # Run batch reset
+        batch_MA, batch_MR, batch_MF = batch_reset(keys)
+
+        # Verify shapes
+        self.assertEqual(batch_MA.shape, (batch_size, 5))
+        self.assertEqual(batch_MR.shape, (batch_size, 5))
+        self.assertEqual(batch_MF.shape, (batch_size, 5))
+
+        # Verify states sum to 1 for each instance
+        totals = batch_MA + batch_MR + batch_MF
+        np.testing.assert_allclose(totals, jp.ones_like(totals))
+
+    def test_get_effort_vmap(self):
+        """Test that get_effort works with vmap"""
+        batch_size = 2
+        batch_acts = jp.stack([self.test_act] * batch_size)
+
+        # Define a batched computation using vmap and JIT
+        @jax.jit
+        def batch_effort(acts):
+            def single_effort(act):
+                fatigue = JaxCumulativeFatigue(self.model, frame_skip=self.frame_skip)
+                fatigue.compute_act(act)
+                return fatigue.get_effort()
+
+            return jax.vmap(single_effort)(acts)
+
+        # Run batch computation
+        batch_efforts = batch_effort(batch_acts)
+
+        # Verify shapes
+        self.assertEqual(batch_efforts.shape, (batch_size,))
+
+        # Verify against sequential computation
+        for i in range(batch_size):
+            fatigue = JaxCumulativeFatigue(self.model, frame_skip=self.frame_skip)
+            fatigue.compute_act(batch_acts[i])
+            effort = fatigue.get_effort()
+            np.testing.assert_allclose(effort, batch_efforts[i])
+
+    def test_numpy_jax_compute_act(self):
+        """Test that JAX and NumPy compute_act produce the same results"""
+        numpy_fatigue = NumpyCumulativeFatigue(self.model, frame_skip=self.frame_skip)
+        jax_fatigue = JaxCumulativeFatigue(self.model, frame_skip=self.frame_skip)
+
+        # Test sequence of activations
+        test_acts = [
+            np.zeros(5, dtype=np.float32),  # Zero activation
+            np.ones(5, dtype=np.float32),  # Full activation
+            np.array([0.3, 0.5, 0.7, 0.2, 0.8], dtype=np.float32),  # Mixed activation
+            np.array([0.5] * 5, dtype=np.float32),  # Uniform activation
+        ]
+
+        for act in test_acts:
+            numpy_MA, numpy_MR, numpy_MF = numpy_fatigue.compute_act(act)
+            jax_MA, jax_MR, jax_MF = jax_fatigue.compute_act(
+                jp.array(act, dtype=jp.float32)
+            )
+
+            np.testing.assert_allclose(
+                numpy_MA,
+                np.array(jax_MA),
+                rtol=1e-5,
+                err_msg=f"MA mismatch for activation {act}",
+            )
+            np.testing.assert_allclose(
+                numpy_MR,
+                np.array(jax_MR),
+                rtol=1e-5,
+                err_msg=f"MR mismatch for activation {act}",
+            )
+            np.testing.assert_allclose(
+                numpy_MF,
+                np.array(jax_MF),
+                rtol=1e-5,
+                err_msg=f"MF mismatch for activation {act}",
+            )
+
+    def test_numpy_jax_effort(self):
+        """Test that JAX and NumPy effort calculations match"""
+        numpy_fatigue = NumpyCumulativeFatigue(self.model, frame_skip=self.frame_skip)
+        jax_fatigue = JaxCumulativeFatigue(self.model, frame_skip=self.frame_skip)
+
+        # Test with different activations
+        test_acts = [
+            np.zeros(5, dtype=np.float32),
+            np.ones(5, dtype=np.float32),
+            np.array([0.3, 0.5, 0.7, 0.2, 0.8], dtype=np.float32),
+            np.array([0.5] * 5, dtype=np.float32),
+        ]
+
+        for act in test_acts:
+            # Update states
+            numpy_fatigue.compute_act(act)
+            jax_fatigue.compute_act(act)
+
+            # Compare efforts
+            numpy_effort = numpy_fatigue.get_effort()
+            jax_effort = float(jax_fatigue.get_effort())
+
+            np.testing.assert_allclose(
+                numpy_effort,
+                jax_effort,
+                rtol=1e-5,
+                err_msg=f"Effort mismatch for activation {act}",
+            )
+
+    def test_numpy_jax_parameters(self):
+        """Test that JAX and NumPy parameter updates behave the same"""
+        numpy_fatigue = NumpyCumulativeFatigue(self.model, frame_skip=self.frame_skip)
+        jax_fatigue = JaxCumulativeFatigue(self.model, frame_skip=self.frame_skip)
+
+        # Test Fatigue coefficient
+        new_F = 0.02
+        numpy_fatigue.set_FatigueCoefficient(new_F)
+        jax_fatigue.set_FatigueCoefficient(new_F)
+        np.testing.assert_allclose(numpy_fatigue.F, float(jax_fatigue.F))
+
+        # Test Recovery coefficient
+        new_R = 0.003
+        numpy_fatigue.set_RecoveryCoefficient(new_R)
+        jax_fatigue.set_RecoveryCoefficient(new_R)
+        np.testing.assert_allclose(numpy_fatigue.R, float(jax_fatigue.R))
+
+        # Test Recovery multiplier
+        new_r = 12
+        numpy_fatigue.set_RecoveryMultiplier(new_r)
+        jax_fatigue.set_RecoveryMultiplier(new_r)
+        np.testing.assert_allclose(numpy_fatigue.r, float(jax_fatigue.r))
+
+        # Verify behavior with updated parameters
+        act = np.array([0.5] * 5, dtype=np.float32)
+        numpy_MA, _, _ = numpy_fatigue.compute_act(act)
+        jax_MA, _, _ = jax_fatigue.compute_act(act)
+        np.testing.assert_allclose(
+            numpy_MA,
+            np.array(jax_MA),
+            rtol=1e-5,
+            err_msg="MA mismatch after parameter updates",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/myosuite/tests/mjx/test_quat_math.py
+++ b/myosuite/tests/mjx/test_quat_math.py
@@ -1,0 +1,2063 @@
+import unittest
+import numpy as np
+import jax
+import jax.numpy as jp
+
+# Configure JAX to use CPU to avoid potential GPU-related issues
+jax.config.update("jax_platform_name", "cpu")
+
+from myosuite.utils.quat_math import (
+    mulQuat as np_mulQuat,
+    negQuat as np_negQuat,
+    quat2Vel as np_quat2Vel,
+    diffQuat as np_diffQuat,
+    quatDiff2Vel as np_quatDiff2Vel,
+    axis_angle2quat as np_axis_angle2quat,
+    euler2mat as np_euler2mat,
+    intrinsic_euler2quat as np_euler2quat,
+    mat2euler as np_mat2euler,
+    mat2quat as np_mat2quat,
+    quat2euler as np_quat2euler,
+    quat2mat as np_quat2mat,
+    rotVecMatT as np_rotVecMatT,
+    rotVecMat as np_rotVecMat,
+    rotVecQuat as np_rotVecQuat,
+    quat2euler_intrinsic as np_quat2euler_intrinsic,
+)
+from myosuite.utils.quat_math_jax import (
+    mulQuat as jax_mulQuat,
+    negQuat as jax_negQuat,
+    quat2Vel as jax_quat2Vel,
+    diffQuat as jax_diffQuat,
+    quatDiff2Vel as jax_quatDiff2Vel,
+    axis_angle2quat as jax_axis_angle2quat,
+    euler2mat as jax_euler2mat,
+    intrinsic_euler2quat as jax_euler2quat,
+    mat2euler as jax_mat2euler,
+    mat2quat as jax_mat2quat,
+    quat2euler as jax_quat2euler,
+    quat2mat as jax_quat2mat,
+    rotVecMatT as jax_rotVecMatT,
+    rotVecMat as jax_rotVecMat,
+    rotVecQuat as jax_rotVecQuat,
+    quat2euler_intrinsic as jax_quat2euler_intrinsic,
+)
+
+
+class TestQuatMath(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        """Initialize JAX"""
+        # Ensure JAX is initialized on CPU
+        cls.device = jax.devices("cpu")[0]
+
+    def setUp(self):
+        # Define some test quaternions with explicit dtype
+        self.test_cases = [
+            # Identity quaternion
+            (
+                np.array([1.0, 0.0, 0.0, 0.0], dtype=np.float32),
+                np.array([0.7071, 0.7071, 0.0, 0.0], dtype=np.float32),
+            ),
+            # 90-degree rotations around different axes
+            (
+                np.array([0.7071, 0.7071, 0.0, 0.0], dtype=np.float32),
+                np.array([0.7071, 0.0, 0.7071, 0.0], dtype=np.float32),
+            ),
+            # Arbitrary quaternions
+            (
+                np.array([0.5, 0.5, 0.5, 0.5], dtype=np.float32),
+                np.array([0.5, -0.5, 0.5, -0.5], dtype=np.float32),
+            ),
+            # Zero rotation
+            (
+                np.array([1.0, 0.0, 0.0, 0.0], dtype=np.float32),
+                np.array([1.0, 0.0, 0.0, 0.0], dtype=np.float32),
+            ),
+        ]
+
+        # Additional test cases specifically for negQuat
+        self.neg_test_cases = [
+            np.array([1.0, 0.0, 0.0, 0.0], dtype=np.float32),  # Identity
+            np.array([0.0, 1.0, 0.0, 0.0], dtype=np.float32),  # Pure i
+            np.array([0.0, 0.0, 1.0, 0.0], dtype=np.float32),  # Pure j
+            np.array([0.0, 0.0, 0.0, 1.0], dtype=np.float32),  # Pure k
+            np.array([0.5, 0.5, 0.5, 0.5], dtype=np.float32),  # Equal components
+            np.array(
+                [0.7071, 0.7071, 0.0, 0.0], dtype=np.float32
+            ),  # 90-degree rotation
+        ]
+
+        # Add test cases for quat2Vel
+        self.vel_test_cases = [
+            # No rotation (identity quaternion)
+            np.array([1.0, 0.0, 0.0, 0.0], dtype=np.float32),
+            # 90-degree rotation around x-axis
+            np.array(
+                [0.7071067811865476, 0.7071067811865476, 0.0, 0.0], dtype=np.float32
+            ),
+            # 90-degree rotation around y-axis
+            np.array(
+                [0.7071067811865476, 0.0, 0.7071067811865476, 0.0], dtype=np.float32
+            ),
+            # 90-degree rotation around z-axis
+            np.array(
+                [0.7071067811865476, 0.0, 0.0, 0.7071067811865476], dtype=np.float32
+            ),
+            # 45-degree rotation around x-axis
+            np.array(
+                [0.9238795325112867, 0.3826834323650898, 0.0, 0.0], dtype=np.float32
+            ),
+            # Arbitrary rotation
+            np.array([0.5, 0.5, 0.5, 0.5], dtype=np.float32),
+        ]
+
+        # Expected results for dt=1.0
+        self.vel_expected_results = [
+            # For identity quaternion: no rotation
+            (0.0, np.array([0.0, 0.0, 0.0], dtype=np.float32)),
+            # For 90-degree rotation around x: pi/2 speed, [1,0,0] axis
+            (np.pi / 2, np.array([1.0, 0.0, 0.0], dtype=np.float32)),
+            # For 90-degree rotation around y: pi/2 speed, [0,1,0] axis
+            (np.pi / 2, np.array([0.0, 1.0, 0.0], dtype=np.float32)),
+            # For 90-degree rotation around z: pi/2 speed, [0,0,1] axis
+            (np.pi / 2, np.array([0.0, 0.0, 1.0], dtype=np.float32)),
+            # For 45-degree rotation around x: pi/4 speed, [1,0,0] axis
+            (np.pi / 4, np.array([1.0, 0.0, 0.0], dtype=np.float32)),
+            # For arbitrary rotation: specific values
+            (
+                2 * np.arccos(0.5),
+                np.array([1.0, 1.0, 1.0] / np.sqrt(3), dtype=np.float32),
+            ),
+        ]
+
+        # Add test cases for diffQuat
+        self.diff_test_cases = [
+            # Same quaternions (should result in identity)
+            (
+                np.array([1.0, 0.0, 0.0, 0.0], dtype=np.float32),  # Identity
+                np.array([1.0, 0.0, 0.0, 0.0], dtype=np.float32),
+            ),
+            # 90-degree difference around x-axis
+            (
+                np.array([1.0, 0.0, 0.0, 0.0], dtype=np.float32),  # Identity
+                np.array(
+                    [0.7071067811865476, 0.7071067811865476, 0.0, 0.0], dtype=np.float32
+                ),
+            ),
+            # 90-degree difference around y-axis
+            (
+                np.array([1.0, 0.0, 0.0, 0.0], dtype=np.float32),  # Identity
+                np.array(
+                    [0.7071067811865476, 0.0, 0.7071067811865476, 0.0], dtype=np.float32
+                ),
+            ),
+            # 180-degree difference around z-axis
+            (
+                np.array([1.0, 0.0, 0.0, 0.0], dtype=np.float32),  # Identity
+                np.array([0.0, 0.0, 0.0, 1.0], dtype=np.float32),
+            ),
+            # Arbitrary rotations
+            (
+                np.array([0.5, 0.5, 0.5, 0.5], dtype=np.float32),
+                np.array([0.5, -0.5, 0.5, -0.5], dtype=np.float32),
+            ),
+        ]
+
+        # Expected results for diffQuat
+        self.diff_expected_results = [
+            np.array(
+                [1.0, 0.0, 0.0, 0.0], dtype=np.float32
+            ),  # Identity (no difference)
+            np.array(
+                [0.7071067811865476, 0.7071067811865476, 0.0, 0.0], dtype=np.float32
+            ),  # 90-deg x
+            np.array(
+                [0.7071067811865476, 0.0, 0.7071067811865476, 0.0], dtype=np.float32
+            ),  # 90-deg y
+            np.array([0.0, 0.0, 0.0, 1.0], dtype=np.float32),  # 180-deg z
+            np.array(
+                [0.0, -1.0, 0.0, 0.0], dtype=np.float32
+            ),  # Result for arbitrary case
+        ]
+
+        # Add test cases for quatDiff2Vel
+        self.diff2vel_test_cases = [
+            # No rotation difference
+            (
+                np.array([1.0, 0.0, 0.0, 0.0], dtype=np.float32),  # Identity
+                np.array([1.0, 0.0, 0.0, 0.0], dtype=np.float32),
+            ),  # Identity
+            # 90-degree rotation difference around x-axis
+            (
+                np.array([1.0, 0.0, 0.0, 0.0], dtype=np.float32),  # Identity
+                np.array(
+                    [0.7071067811865476, 0.7071067811865476, 0.0, 0.0], dtype=np.float32
+                ),
+            ),
+            # 90-degree rotation difference around y-axis
+            (
+                np.array([1.0, 0.0, 0.0, 0.0], dtype=np.float32),  # Identity
+                np.array(
+                    [0.7071067811865476, 0.0, 0.7071067811865476, 0.0], dtype=np.float32
+                ),
+            ),
+            # 180-degree rotation difference around z-axis
+            (
+                np.array([1.0, 0.0, 0.0, 0.0], dtype=np.float32),  # Identity
+                np.array([0.0, 0.0, 0.0, 1.0], dtype=np.float32),
+            ),
+            # Arbitrary rotation difference
+            (
+                np.array([0.5, 0.5, 0.5, 0.5], dtype=np.float32),
+                np.array([0.5, -0.5, 0.5, -0.5], dtype=np.float32),
+            ),
+        ]
+
+        # Expected results for quatDiff2Vel (dt=1.0)
+        self.diff2vel_expected_results = [
+            # No rotation: zero angular velocity
+            (0.0, np.array([0.0, 0.0, 0.0], dtype=np.float32)),
+            # 90-degree rotation around x: pi/2 speed, [1,0,0] axis
+            (np.pi / 2, np.array([1.0, 0.0, 0.0], dtype=np.float32)),
+            # 90-degree rotation around y: pi/2 speed, [0,1,0] axis
+            (np.pi / 2, np.array([0.0, 1.0, 0.0], dtype=np.float32)),
+            # 180-degree rotation around z: pi speed, [0,0,1] axis
+            (np.pi, np.array([0.0, 0.0, 1.0], dtype=np.float32)),
+            # Arbitrary rotation: specific values
+            (np.pi, np.array([1.0, 0.0, 0.0], dtype=np.float32)),
+        ]
+
+        # Add test cases for axis_angle2quat
+        self.axis_angle_test_cases = [
+            # No rotation
+            (np.array([1.0, 0.0, 0.0], dtype=np.float32), 0.0),
+            # 90-degree rotations around principal axes
+            (np.array([1.0, 0.0, 0.0], dtype=np.float32), np.pi / 2),
+            (np.array([0.0, 1.0, 0.0], dtype=np.float32), np.pi / 2),
+            (np.array([0.0, 0.0, 1.0], dtype=np.float32), np.pi / 2),
+            # 180-degree rotation
+            (np.array([0.0, 0.0, 1.0], dtype=np.float32), np.pi),
+            # 45-degree rotation around arbitrary axis
+            (np.array([1.0, 1.0, 1.0], dtype=np.float32) / np.sqrt(3), np.pi / 4),
+        ]
+
+        # Expected results for axis_angle2quat
+        self.axis_angle_expected_results = [
+            np.array([1.0, 0.0, 0.0, 0.0], dtype=np.float32),
+            np.array(
+                [0.7071067811865476, 0.7071067811865476, 0.0, 0.0], dtype=np.float32
+            ),
+            np.array(
+                [0.7071067811865476, 0.0, 0.7071067811865476, 0.0], dtype=np.float32
+            ),
+            np.array(
+                [0.7071067811865476, 0.0, 0.0, 0.7071067811865476], dtype=np.float32
+            ),
+            np.array([0.0, 0.0, 0.0, 1.0], dtype=np.float32),
+            np.array([0.92388, 0.220942, 0.220942, 0.220942], dtype=np.float32),
+        ]
+
+        # Add test cases for euler2mat
+        self.euler_test_cases = [
+            # No rotation
+            np.array([0.0, 0.0, 0.0], dtype=np.float32),
+            # 90-degree rotations around single axes
+            np.array([np.pi / 2, 0.0, 0.0], dtype=np.float32),
+            np.array([0.0, np.pi / 2, 0.0], dtype=np.float32),
+            np.array([0.0, 0.0, np.pi / 2], dtype=np.float32),
+            # Combined rotations
+            np.array([np.pi / 4, np.pi / 4, 0.0], dtype=np.float32),
+            np.array([np.pi / 3, np.pi / 6, np.pi / 2], dtype=np.float32),
+        ]
+
+        # Add test cases for euler2quat
+        self.euler2quat_test_cases = [
+            # No rotation
+            np.array([0.0, 0.0, 0.0], dtype=np.float32),
+            # Single axis rotations - 90 degrees
+            np.array([np.pi / 2, 0.0, 0.0], dtype=np.float32),  # Roll
+            np.array([0.0, np.pi / 2, 0.0], dtype=np.float32),  # Pitch
+            np.array([0.0, 0.0, np.pi / 2], dtype=np.float32),  # Yaw
+            # Single axis rotations - 45 degrees
+            np.array([np.pi / 4, 0.0, 0.0], dtype=np.float32),
+            np.array([0.0, np.pi / 4, 0.0], dtype=np.float32),
+            np.array([0.0, 0.0, np.pi / 4], dtype=np.float32),
+            # Combined rotations
+            np.array([np.pi / 4, np.pi / 4, 0.0], dtype=np.float32),
+            np.array([np.pi / 4, 0.0, np.pi / 4], dtype=np.float32),
+            np.array([0.0, np.pi / 4, np.pi / 4], dtype=np.float32),
+            np.array([np.pi / 6, np.pi / 4, np.pi / 3], dtype=np.float32),
+        ]
+
+        # Expected results for euler2quat
+        self.euler2quat_expected_results = [
+            # Identity quaternion for no rotation
+            np.array([1.0, 0.0, 0.0, 0.0], dtype=np.float32),
+            # 90-degree rotations around principal axes
+            np.array([0.7071068, 0.7071068, 0.0, 0.0], dtype=np.float32),  # Roll
+            np.array([0.7071068, 0.0, 0.7071068, 0.0], dtype=np.float32),  # Pitch
+            np.array([0.7071068, 0.0, 0.0, 0.7071068], dtype=np.float32),  # Yaw
+            # 45-degree rotations around principal axes
+            np.array([0.9238795, 0.3826834, 0.0, 0.0], dtype=np.float32),
+            np.array([0.9238795, 0.0, 0.3826834, 0.0], dtype=np.float32),
+            np.array([0.9238795, 0.0, 0.0, 0.3826834], dtype=np.float32),
+            # Combined rotations (pre-computed values)
+            np.array([0.853553, 0.353553, 0.353553, -0.146447], dtype=np.float32),
+            np.array([0.853553, 0.353553, 0.146447, 0.353553], dtype=np.float32),
+            np.array([0.85355335, -0.14644663, 0.3535534, 0.3535534], dtype=np.float32),
+            np.array([0.822363, 0.02226, 0.43968, 0.360423], dtype=np.float32),
+        ]
+
+        # Add test cases for mat2euler
+        self.mat2euler_test_cases = [
+            # Identity matrix (no rotation)
+            np.eye(3, dtype=np.float32),
+            # 90-degree rotations around principal axes
+            np.array(
+                [[1.0, 0.0, 0.0], [0.0, 0.0, -1.0], [0.0, 1.0, 0.0]], dtype=np.float32
+            ),  # 90° around x
+            np.array(
+                [[0.0, 0.0, 1.0], [0.0, 1.0, 0.0], [-1.0, 0.0, 0.0]], dtype=np.float32
+            ),  # 90° around y
+            np.array(
+                [[0.0, -1.0, 0.0], [1.0, 0.0, 0.0], [0.0, 0.0, 1.0]], dtype=np.float32
+            ),  # 90° around z
+            # 45-degree rotations
+            np.array(
+                [
+                    [1.0, 0.0, 0.0],
+                    [0.0, 0.7071068, -0.7071068],
+                    [0.0, 0.7071068, 0.7071068],
+                ],
+                dtype=np.float32,
+            ),  # 45° around x
+            np.array(
+                [
+                    [0.7071068, 0.0, 0.7071068],
+                    [0.0, 1.0, 0.0],
+                    [-0.7071068, 0.0, 0.7071068],
+                ],
+                dtype=np.float32,
+            ),  # 45° around y
+            np.array(
+                [
+                    [0.7071068, -0.7071068, 0.0],
+                    [0.7071068, 0.7071068, 0.0],
+                    [0.0, 0.0, 1.0],
+                ],
+                dtype=np.float32,
+            ),  # 45° around z
+            # Combined rotations
+            np.array(
+                [
+                    [0.3536, -0.6124, 0.7071],
+                    [0.866007, 0.500033, 0.0],
+                    [-0.353576, 0.612359, 0.707107],
+                ],
+                dtype=np.float32,
+            ),  # Combined rotation
+        ]
+
+        # Expected Euler angles for each rotation matrix
+        self.mat2euler_expected_results = [
+            np.array([0.0, 0.0, 0.0], dtype=np.float32),  # No rotation
+            np.array([np.pi / 2, 0.0, 0.0], dtype=np.float32),  # 90° x
+            np.array([0.0, np.pi / 2, 0.0], dtype=np.float32),  # 90° y
+            np.array([0.0, 0.0, np.pi / 2], dtype=np.float32),  # 90° z
+            np.array([np.pi / 4, 0.0, 0.0], dtype=np.float32),  # 45° x
+            np.array([0.0, np.pi / 4, 0.0], dtype=np.float32),  # 45° y
+            np.array([0.0, 0.0, np.pi / 4], dtype=np.float32),  # 45° z
+            np.array([0.0, np.pi / 4, np.pi / 3], dtype=np.float32),  # Combined
+        ]
+
+        # Add test cases for mat2quat
+        self.mat2quat_test_cases = [
+            # Identity matrix (no rotation)
+            np.eye(3, dtype=np.float32),
+            # 90-degree rotations around principal axes
+            np.array(
+                [[1.0, 0.0, 0.0], [0.0, 0.0, -1.0], [0.0, 1.0, 0.0]], dtype=np.float32
+            ),  # 90° around x
+            np.array(
+                [[0.0, 0.0, 1.0], [0.0, 1.0, 0.0], [-1.0, 0.0, 0.0]], dtype=np.float32
+            ),  # 90° around y
+            np.array(
+                [[0.0, -1.0, 0.0], [1.0, 0.0, 0.0], [0.0, 0.0, 1.0]], dtype=np.float32
+            ),  # 90° around z
+            # 45-degree rotations
+            np.array(
+                [
+                    [1.0, 0.0, 0.0],
+                    [0.0, 0.7071068, -0.7071068],
+                    [0.0, 0.7071068, 0.7071068],
+                ],
+                dtype=np.float32,
+            ),  # 45° around x
+            np.array(
+                [
+                    [0.7071068, 0.0, 0.7071068],
+                    [0.0, 1.0, 0.0],
+                    [-0.7071068, 0.0, 0.7071068],
+                ],
+                dtype=np.float32,
+            ),  # 45° around y
+            np.array(
+                [
+                    [0.7071068, -0.7071068, 0.0],
+                    [0.7071068, 0.7071068, 0.0],
+                    [0.0, 0.0, 1.0],
+                ],
+                dtype=np.float32,
+            ),  # 45° around z
+            # Combined rotation
+            np.array(
+                [
+                    [0.3536, -0.6124, 0.7071],
+                    [0.866007, 0.500033, 0.0],
+                    [-0.353576, 0.612359, 0.707107],
+                ],
+                dtype=np.float32,
+            ),
+        ]
+
+        # Expected quaternions for each rotation matrix
+        self.mat2quat_expected_results = [
+            np.array([1.0, 0.0, 0.0, 0.0], dtype=np.float32),  # Identity
+            np.array([0.7071068, 0.7071068, 0.0, 0.0], dtype=np.float32),  # 90° x
+            np.array([0.7071068, 0.0, 0.7071068, 0.0], dtype=np.float32),  # 90° y
+            np.array([0.7071068, 0.0, 0.0, 0.7071068], dtype=np.float32),  # 90° z
+            np.array([0.9238795, 0.3826834, 0.0, 0.0], dtype=np.float32),  # 45° x
+            np.array([0.9238795, 0.0, 0.3826834, 0.0], dtype=np.float32),  # 45° y
+            np.array([0.9238795, 0.0, 0.0, 0.3826834], dtype=np.float32),  # 45° z
+            np.array(
+                [0.80011504, 0.19133107, 0.33140944, 0.46192655], dtype=np.float32
+            ),  # Combined
+        ]
+
+        # Add test cases for quat2euler
+        self.quat2euler_test_cases = [
+            # Identity quaternion (no rotation)
+            np.array([1.0, 0.0, 0.0, 0.0], dtype=np.float32),
+            # 90-degree rotations around principal axes
+            np.array([0.7071068, 0.7071068, 0.0, 0.0], dtype=np.float32),  # x-axis
+            np.array([0.7071068, 0.0, 0.7071068, 0.0], dtype=np.float32),  # y-axis
+            np.array([0.7071068, 0.0, 0.0, 0.7071068], dtype=np.float32),  # z-axis
+            # 45-degree rotations around principal axes
+            np.array([0.9238795, 0.3826834, 0.0, 0.0], dtype=np.float32),  # x-axis
+            np.array([0.9238795, 0.0, 0.3826834, 0.0], dtype=np.float32),  # y-axis
+            np.array([0.9238795, 0.0, 0.0, 0.3826834], dtype=np.float32),  # z-axis
+            # Combined rotation
+            np.array(
+                [0.80011504, 0.19133107, 0.33140944, 0.46192655], dtype=np.float32
+            ),
+        ]
+
+        # Expected Euler angles for each quaternion
+        self.quat2euler_expected_results = [
+            np.array([0.0, 0.0, 0.0], dtype=np.float32),  # No rotation
+            np.array([np.pi / 2, 0.0, 0.0], dtype=np.float32),  # 90° x
+            np.array([0.0, np.pi / 2, 0.0], dtype=np.float32),  # 90° y
+            np.array([0.0, 0.0, np.pi / 2], dtype=np.float32),  # 90° z
+            np.array([np.pi / 4, 0.0, 0.0], dtype=np.float32),  # 45° x
+            np.array([0.0, np.pi / 4, 0.0], dtype=np.float32),  # 45° y
+            np.array([0.0, 0.0, np.pi / 4], dtype=np.float32),  # 45° z
+            np.array([0.0, np.pi / 4, np.pi / 3], dtype=np.float32),  # Combined
+        ]
+
+        # Add test cases for quat2mat
+        self.quat2mat_test_cases = [
+            # Identity quaternion (no rotation)
+            np.array([1.0, 0.0, 0.0, 0.0], dtype=np.float32),
+            # 90-degree rotations around principal axes
+            np.array([0.7071068, 0.7071068, 0.0, 0.0], dtype=np.float32),  # x-axis
+            np.array([0.7071068, 0.0, 0.7071068, 0.0], dtype=np.float32),  # y-axis
+            np.array([0.7071068, 0.0, 0.0, 0.7071068], dtype=np.float32),  # z-axis
+            # 45-degree rotations around principal axes
+            np.array([0.9238795, 0.3826834, 0.0, 0.0], dtype=np.float32),  # x-axis
+            np.array([0.9238795, 0.0, 0.3826834, 0.0], dtype=np.float32),  # y-axis
+            np.array([0.9238795, 0.0, 0.0, 0.3826834], dtype=np.float32),  # z-axis
+            # Combined rotation
+            np.array(
+                [0.80011504, 0.19133107, 0.33140944, 0.46192655], dtype=np.float32
+            ),
+        ]
+
+        # Expected rotation matrices for each quaternion
+        self.quat2mat_expected_results = [
+            # Identity matrix
+            np.eye(3, dtype=np.float32),
+            # 90-degree rotation matrices around principal axes
+            np.array(
+                [[1.0, 0.0, 0.0], [0.0, 0.0, -1.0], [0.0, 1.0, 0.0]], dtype=np.float32
+            ),  # x-axis
+            np.array(
+                [[0.0, 0.0, 1.0], [0.0, 1.0, 0.0], [-1.0, 0.0, 0.0]], dtype=np.float32
+            ),  # y-axis
+            np.array(
+                [[0.0, -1.0, 0.0], [1.0, 0.0, 0.0], [0.0, 0.0, 1.0]], dtype=np.float32
+            ),  # z-axis
+            # 45-degree rotation matrices
+            np.array(
+                [
+                    [1.0, 0.0, 0.0],
+                    [0.0, 0.7071068, -0.7071068],
+                    [0.0, 0.7071068, 0.7071068],
+                ],
+                dtype=np.float32,
+            ),  # x-axis
+            np.array(
+                [
+                    [0.7071068, 0.0, 0.7071068],
+                    [0.0, 1.0, 0.0],
+                    [-0.7071068, 0.0, 0.7071068],
+                ],
+                dtype=np.float32,
+            ),  # y-axis
+            np.array(
+                [
+                    [0.7071068, -0.7071068, 0.0],
+                    [0.7071068, 0.7071068, 0.0],
+                    [0.0, 0.0, 1.0],
+                ],
+                dtype=np.float32,
+            ),  # z-axis
+            # Combined rotation matrix
+            np.array(
+                [
+                    [0.3536, -0.6124, 0.7071],
+                    [0.866007, 0.500033, 0.0],
+                    [-0.353576, 0.612359, 0.707107],
+                ],
+                dtype=np.float32,
+            ),
+        ]
+
+        # Add test cases for rotVecMatT
+        self.rotVecMatT_test_cases = [
+            # Identity rotation (no change)
+            (
+                np.array([1.0, 0.0, 0.0], dtype=np.float32),  # x-axis vector
+                np.eye(3, dtype=np.float32),
+            ),  # identity matrix
+            (
+                np.array([0.0, 1.0, 0.0], dtype=np.float32),  # y-axis vector
+                np.eye(3, dtype=np.float32),
+            ),  # identity matrix
+            # 90-degree rotations
+            (
+                np.array([1.0, 0.0, 0.0], dtype=np.float32),  # x-axis vector
+                np.array(
+                    [[1.0, 0.0, 0.0], [0.0, 0.0, -1.0], [0.0, 1.0, 0.0]],
+                    dtype=np.float32,
+                ),
+            ),  # 90° around x
+            (
+                np.array([0.0, 1.0, 0.0], dtype=np.float32),  # y-axis vector
+                np.array(
+                    [[0.0, 0.0, 1.0], [0.0, 1.0, 0.0], [-1.0, 0.0, 0.0]],
+                    dtype=np.float32,
+                ),
+            ),  # 90° around y
+            # 45-degree rotation
+            (
+                np.array([1.0, 1.0, 1.0], dtype=np.float32),  # diagonal vector
+                np.array(
+                    [
+                        [0.7071068, -0.7071068, 0.0],
+                        [0.7071068, 0.7071068, 0.0],
+                        [0.0, 0.0, 1.0],
+                    ],
+                    dtype=np.float32,
+                ),
+            ),  # 45° around z
+            # Arbitrary vector and rotation
+            (
+                np.array([0.5, -0.3, 0.8], dtype=np.float32),
+                np.array(
+                    [
+                        [0.3536, -0.6124, 0.7071],
+                        [0.866007, 0.500033, 0.0],
+                        [-0.353576, 0.612359, 0.707107],
+                    ],
+                    dtype=np.float32,
+                ),
+            ),
+        ]
+
+        # Expected results for rotVecMatT
+        self.rotVecMatT_expected_results = [
+            np.array([1.0, 0.0, 0.0], dtype=np.float32),  # No change for identity
+            np.array([0.0, 1.0, 0.0], dtype=np.float32),  # No change for identity
+            np.array([1.0, 0.0, 0.0], dtype=np.float32),  # 90° x rotation
+            np.array([0.0, 1.0, 0.0], dtype=np.float32),  # 90° y rotation
+            np.array([1.414214, 0.0, 1.0], dtype=np.float32),  # 45° z rotation
+            np.array(
+                [-0.365863, 0.033677, 0.919236], dtype=np.float32
+            ),  # Arbitrary rotation
+        ]
+
+        # Add test cases for rotVecMat
+        self.rotVecMat_test_cases = [
+            # Identity rotation (no change)
+            (
+                np.array([1.0, 0.0, 0.0], dtype=np.float32),  # x-axis vector
+                np.eye(3, dtype=np.float32),
+            ),  # identity matrix
+            (
+                np.array([0.0, 1.0, 0.0], dtype=np.float32),  # y-axis vector
+                np.eye(3, dtype=np.float32),
+            ),  # identity matrix
+            # 90-degree rotations
+            (
+                np.array([1.0, 0.0, 0.0], dtype=np.float32),  # x-axis vector
+                np.array(
+                    [[1.0, 0.0, 0.0], [0.0, 0.0, -1.0], [0.0, 1.0, 0.0]],
+                    dtype=np.float32,
+                ),
+            ),  # 90° around x
+            (
+                np.array([0.0, 1.0, 0.0], dtype=np.float32),  # y-axis vector
+                np.array(
+                    [[0.0, 0.0, 1.0], [0.0, 1.0, 0.0], [-1.0, 0.0, 0.0]],
+                    dtype=np.float32,
+                ),
+            ),  # 90° around y
+            # 45-degree rotation
+            (
+                np.array([1.0, 1.0, 1.0], dtype=np.float32),  # diagonal vector
+                np.array(
+                    [
+                        [0.7071068, -0.7071068, 0.0],
+                        [0.7071068, 0.7071068, 0.0],
+                        [0.0, 0.0, 1.0],
+                    ],
+                    dtype=np.float32,
+                ),
+            ),  # 45° around z
+            # Arbitrary vector and rotation
+            (
+                np.array([0.5, -0.3, 0.8], dtype=np.float32),
+                np.array(
+                    [
+                        [0.3536, -0.6124, 0.7071],
+                        [0.866007, 0.500033, 0.0],
+                        [-0.353576, 0.612359, 0.707107],
+                    ],
+                    dtype=np.float32,
+                ),
+            ),
+        ]
+
+        # Expected results for rotVecMat
+        self.rotVecMat_expected_results = [
+            np.array([1.0, 0.0, 0.0], dtype=np.float32),  # No change for identity
+            np.array([0.0, 1.0, 0.0], dtype=np.float32),  # No change for identity
+            np.array([1.0, 0.0, 0.0], dtype=np.float32),  # 90° x rotation
+            np.array([0.0, 1.0, 0.0], dtype=np.float32),  # 90° y rotation
+            np.array([0.0, 1.414214, 1.0], dtype=np.float32),  # 45° z rotation
+            np.array(
+                [0.9262, 0.282994, 0.20519], dtype=np.float32
+            ),  # Arbitrary rotation
+        ]
+
+        # Add test cases for rotVecQuat
+        self.rotVecQuat_test_cases = [
+            # Identity rotation (no change)
+            (
+                np.array([1.0, 0.0, 0.0], dtype=np.float32),  # x-axis vector
+                np.array([1.0, 0.0, 0.0, 0.0], dtype=np.float32),
+            ),  # identity quaternion
+            # 90-degree rotations
+            (
+                np.array([1.0, 0.0, 0.0], dtype=np.float32),  # x-axis vector
+                np.array([0.7071068, 0.7071068, 0.0, 0.0], dtype=np.float32),
+            ),  # 90° around x
+            (
+                np.array([0.0, 1.0, 0.0], dtype=np.float32),  # y-axis vector
+                np.array([0.7071068, 0.0, 0.7071068, 0.0], dtype=np.float32),
+            ),  # 90° around y
+            # 45-degree rotation
+            (
+                np.array([1.0, 1.0, 1.0], dtype=np.float32),  # diagonal vector
+                np.array([0.9238795, 0.0, 0.0, 0.3826834], dtype=np.float32),
+            ),  # 45° around z
+            # Arbitrary vector and rotation
+            (
+                np.array([0.5, -0.3, 0.8], dtype=np.float32),
+                np.array(
+                    [0.80011504, 0.19133107, 0.33140944, 0.46192655], dtype=np.float32
+                ),
+            ),
+        ]
+
+        # Expected results for rotVecQuat (same as corresponding matrix rotations)
+        self.rotVecQuat_expected_results = [
+            np.array([1.0, 0.0, 0.0], dtype=np.float32),  # No change for identity
+            np.array([1.0, 0.0, 0.0], dtype=np.float32),  # 90° x rotation
+            np.array([0.0, 1.0, 0.0], dtype=np.float32),  # 90° y rotation
+            np.array([0.0, 1.414214, 1.0], dtype=np.float32),  # 45° z rotation
+            np.array(
+                [0.9262, 0.282994, 0.20519], dtype=np.float32
+            ),  # Arbitrary rotation
+        ]
+
+        # Add test cases for quat2euler_intrinsic
+        self.quat2euler_intrinsic_test_cases = [
+            # Identity quaternion (no rotation)
+            np.array([1.0, 0.0, 0.0, 0.0], dtype=np.float32),
+            # 90-degree rotations around principal axes
+            np.array([0.7071068, 0.7071068, 0.0, 0.0], dtype=np.float32),  # x-axis
+            np.array([0.7071068, 0.0, 0.7071068, 0.0], dtype=np.float32),  # y-axis
+            np.array([0.7071068, 0.0, 0.0, 0.7071068], dtype=np.float32),  # z-axis
+            # 45-degree rotations around principal axes
+            np.array([0.9238795, 0.3826834, 0.0, 0.0], dtype=np.float32),  # x-axis
+            np.array([0.9238795, 0.0, 0.3826834, 0.0], dtype=np.float32),  # y-axis
+            np.array([0.9238795, 0.0, 0.0, 0.3826834], dtype=np.float32),  # z-axis
+        ]
+
+        # Expected Euler angles for each quaternion
+        self.quat2euler_intrinsic_expected_results = [
+            np.array([0.0, 0.0, 0.0], dtype=np.float32),  # No rotation
+            np.array([np.pi / 2, 0.0, 0.0], dtype=np.float32),  # 90° x
+            np.array([np.pi, np.pi / 2, np.pi], dtype=np.float32),  # 90° y
+            np.array([0.0, 0.0, np.pi / 2], dtype=np.float32),  # 90° z
+            np.array([np.pi / 4, 0.0, 0.0], dtype=np.float32),  # 45° x
+            np.array([0.0, np.pi / 4, 0.0], dtype=np.float32),  # 45° y
+            np.array([0.0, 0.0, np.pi / 4], dtype=np.float32),  # 45° z
+        ]
+
+    def test_mulQuat_implementations_match(self):
+        """Test that JAX and NumPy implementations give the same results"""
+        try:
+            for qa, qb in self.test_cases:
+                # Convert inputs to the appropriate type
+                qa_jax = jp.array(qa, dtype=jp.float32)
+                qb_jax = jp.array(qb, dtype=jp.float32)
+
+                # Compute results from both implementations
+                result_np = np_mulQuat(qa, qb)
+                result_jax = jax_mulQuat(qa_jax, qb_jax)
+
+                # Convert JAX result to numpy for comparison
+                result_jax = np.array(result_jax)
+
+                # Compare results
+                np.testing.assert_allclose(
+                    result_np,
+                    result_jax,
+                    rtol=1e-5,
+                    atol=1e-5,
+                    err_msg=f"Results don't match for qa={qa}, qb={qb}",
+                )
+        except Exception as e:
+            print(f"Error in mulQuat test: {str(e)}")
+            raise
+
+    def test_negQuat_implementations_match(self):
+        """Test that JAX and NumPy implementations of negQuat give the same results"""
+        try:
+            for q in self.neg_test_cases:
+                # Convert input to JAX array
+                print(f"Testing negQuat with input: {q} (type: {q.dtype})")
+                q_jax = jp.array(q, dtype=jp.float32)
+                print(f"JAX array: {q_jax} (type: {q_jax.dtype})")
+
+                # Compute results from both implementations
+                result_np = np_negQuat(q)
+                print(f"NumPy result: {result_np}")
+
+                result_jax = jax_negQuat(q_jax)
+                print(f"JAX result: {result_jax}")
+
+                # Convert JAX result to numpy for comparison
+                result_jax = np.array(result_jax)
+
+                # Compare results
+                np.testing.assert_allclose(
+                    result_np,
+                    result_jax,
+                    rtol=1e-5,
+                    atol=1e-5,
+                    err_msg=f"Results don't match for q={q}",
+                )
+        except Exception as e:
+            print(f"Error in negQuat test: {str(e)}")
+            raise
+
+    def test_negQuat_properties(self):
+        """Test mathematical properties of quaternion negation"""
+        for q in self.neg_test_cases:
+            q_jax = jp.array(q)
+
+            # Test double negation returns original quaternion
+            neg_neg_q = jax_negQuat(jax_negQuat(q_jax))
+            np.testing.assert_allclose(
+                np.array(neg_neg_q),
+                q,
+                rtol=1e-5,
+                atol=1e-5,
+                err_msg=f"Double negation failed for q={q}",
+            )
+
+            # Test that negation preserves norm
+            neg_q = jax_negQuat(q_jax)
+            orig_norm = jp.sqrt(jp.sum(q_jax * q_jax))
+            neg_norm = jp.sqrt(jp.sum(neg_q * neg_q))
+            np.testing.assert_allclose(
+                float(orig_norm),
+                float(neg_norm),
+                rtol=1e-5,
+                atol=1e-5,
+                err_msg=f"Norm not preserved for q={q}",
+            )
+
+    def test_mulQuat_properties(self):
+        """Test mathematical properties of quaternion multiplication"""
+
+        # Test identity quaternion property
+        identity = np.array([1.0, 0.0, 0.0, 0.0])
+        identity_jax = jp.array(identity)
+
+        for qa, _ in self.test_cases:
+            qa_jax = jp.array(qa)
+
+            # Identity * q = q
+            result_jax = jax_mulQuat(identity_jax, qa_jax)
+            np.testing.assert_allclose(
+                np.array(result_jax),
+                qa,
+                rtol=1e-5,
+                atol=1e-5,
+                err_msg=f"Identity property failed for q={qa}",
+            )
+
+            # q * Identity = q
+            result_jax = jax_mulQuat(qa_jax, identity_jax)
+            np.testing.assert_allclose(
+                np.array(result_jax),
+                qa,
+                rtol=1e-5,
+                atol=1e-5,
+                err_msg=f"Identity property failed for q={qa}",
+            )
+
+    def test_mulQuat_norm_preservation(self):
+        """Test that quaternion multiplication preserves norm"""
+        for qa, qb in self.test_cases:
+            qa_jax = jp.array(qa)
+            qb_jax = jp.array(qb)
+
+            # Compute result
+            result = jax_mulQuat(qa_jax, qb_jax)
+
+            # Check that the result is still a unit quaternion
+            norm = jp.sqrt(jp.sum(result * result))
+            np.testing.assert_allclose(
+                float(norm),
+                1.0,
+                rtol=1e-5,
+                atol=1e-5,
+                err_msg=f"Norm not preserved for qa={qa}, qb={qb}",
+            )
+
+    def test_quat2Vel_implementations_match(self):
+        """Test that JAX and NumPy implementations of quat2Vel give the same results"""
+        try:
+            for q, (expected_speed, expected_axis) in zip(
+                self.vel_test_cases, self.vel_expected_results
+            ):
+                # Convert input to JAX array
+                print(f"\nTesting quat2Vel with input: {q} (type: {q.dtype})")
+                q_jax = jp.array(q, dtype=jp.float32)
+
+                # Test with different dt values
+                for dt in [1.0, 0.5, 0.1]:
+                    # Compute results from both implementations
+                    speed_np, axis_np = np_quat2Vel(q, dt)
+                    speed_jax, axis_jax = jax_quat2Vel(q_jax, dt)
+
+                    print(f"dt={dt}")
+                    print(f"NumPy result: speed={speed_np}, axis={axis_np}")
+                    print(f"JAX result: speed={speed_jax}, axis={axis_jax}")
+
+                    # Convert JAX results to numpy for comparison
+                    speed_jax = float(speed_jax)
+                    axis_jax = np.array(axis_jax)
+
+                    # Compare results
+                    np.testing.assert_allclose(
+                        speed_np,
+                        speed_jax,
+                        rtol=1e-5,
+                        atol=1e-5,
+                        err_msg=f"Speed doesn't match for q={q}, dt={dt}",
+                    )
+                    np.testing.assert_allclose(
+                        axis_np,
+                        axis_jax,
+                        rtol=1e-5,
+                        atol=1e-5,
+                        err_msg=f"Axis doesn't match for q={q}, dt={dt}",
+                    )
+
+                    # For dt=1.0, also check against expected results
+                    if dt == 1.0:
+                        np.testing.assert_allclose(
+                            speed_jax,
+                            expected_speed,
+                            rtol=1e-5,
+                            atol=1e-5,
+                            err_msg=f"Speed doesn't match expected for q={q}",
+                        )
+                        np.testing.assert_allclose(
+                            np.abs(axis_jax),
+                            np.abs(expected_axis),
+                            rtol=1e-5,
+                            atol=1e-5,
+                            err_msg=f"Axis doesn't match expected for q={q}",
+                        )
+
+        except Exception as e:
+            print(f"Error in quat2Vel test: {str(e)}")
+            raise
+
+    def test_diffQuat_implementations_match(self):
+        """Test that JAX and NumPy implementations of diffQuat give the same results"""
+        try:
+            for (q1, q2), expected_result in zip(
+                self.diff_test_cases, self.diff_expected_results
+            ):
+                # Convert inputs to JAX arrays
+                print(f"\nTesting diffQuat with inputs: q1={q1}, q2={q2}")
+                q1_jax = jp.array(q1, dtype=jp.float32)
+                q2_jax = jp.array(q2, dtype=jp.float32)
+
+                # Compute results from both implementations
+                result_np = np_diffQuat(q1, q2)
+                result_jax = jax_diffQuat(q1_jax, q2_jax)
+
+                print(f"NumPy result: {result_np}")
+                print(f"JAX result: {result_jax}")
+                print(f"Expected result: {expected_result}")
+
+                # Convert JAX result to numpy for comparison
+                result_jax = np.array(result_jax)
+
+                # Compare results
+                np.testing.assert_allclose(
+                    result_np,
+                    result_jax,
+                    rtol=1e-5,
+                    atol=1e-5,
+                    err_msg=f"Results don't match for q1={q1}, q2={q2}",
+                )
+
+                # Compare with expected results
+                np.testing.assert_allclose(
+                    np.abs(result_jax),
+                    np.abs(expected_result),
+                    rtol=1e-5,
+                    atol=1e-5,
+                    err_msg=f"Result doesn't match expected for q1={q1}, q2={q2}",
+                )
+
+        except Exception as e:
+            print(f"Error in diffQuat test: {str(e)}")
+            raise
+
+    def test_diffQuat_properties(self):
+        """Test mathematical properties of quaternion difference"""
+        try:
+            for q1, q2 in self.diff_test_cases:
+                q1_jax = jp.array(q1, dtype=jp.float32)
+                q2_jax = jp.array(q2, dtype=jp.float32)
+
+                # Property 1: diff(q, q) should be identity quaternion
+                result = jax_diffQuat(q1_jax, q1_jax)
+                identity = jp.array([1.0, 0.0, 0.0, 0.0], dtype=jp.float32)
+                np.testing.assert_allclose(
+                    np.array(result),
+                    identity,
+                    rtol=1e-5,
+                    atol=1e-5,
+                    err_msg=f"Self-difference not identity for q={q1}",
+                )
+
+                # Property 2: Norm preservation
+                result = jax_diffQuat(q1_jax, q2_jax)
+                norm = jp.sqrt(jp.sum(result * result))
+                np.testing.assert_allclose(
+                    float(norm),
+                    1.0,
+                    rtol=1e-5,
+                    atol=1e-5,
+                    err_msg=f"Norm not preserved for q1={q1}, q2={q2}",
+                )
+
+                # Property 3: diff(q1,q2) * q1 = q2 (up to numerical precision)
+                diff_result = jax_diffQuat(q1_jax, q2_jax)
+                reconstructed = jax_mulQuat(diff_result, q1_jax)
+                np.testing.assert_allclose(
+                    np.abs(np.array(reconstructed)),
+                    np.abs(q2),
+                    rtol=1e-5,
+                    atol=1e-5,
+                    err_msg=f"Reconstruction failed for q1={q1}, q2={q2}",
+                )
+
+        except Exception as e:
+            print(f"Error in diffQuat properties test: {str(e)}")
+            raise
+
+    def test_quatDiff2Vel_implementations_match(self):
+        """Test that JAX and NumPy implementations of quatDiff2Vel give the same results"""
+        try:
+            for (q1, q2), (expected_speed, expected_axis) in zip(
+                self.diff2vel_test_cases, self.diff2vel_expected_results
+            ):
+                # Convert inputs to JAX arrays
+                print(f"\nTesting quatDiff2Vel with inputs: q1={q1}, q2={q2}")
+                q1_jax = jp.array(q1, dtype=jp.float32)
+                q2_jax = jp.array(q2, dtype=jp.float32)
+
+                # Test with different dt values
+                for dt in [1.0, 0.5, 0.1]:
+                    # Compute results from both implementations
+                    speed_np, axis_np = np_quatDiff2Vel(q1, q2, dt)
+                    speed_jax, axis_jax = jax_quatDiff2Vel(q1_jax, q2_jax, dt)
+
+                    print(f"dt={dt}")
+                    print(f"NumPy result: speed={speed_np}, axis={axis_np}")
+                    print(f"JAX result: speed={speed_jax}, axis={axis_jax}")
+
+                    # Convert JAX results to numpy for comparison
+                    speed_jax = float(speed_jax)
+                    axis_jax = np.array(axis_jax)
+
+                    # Compare results
+                    np.testing.assert_allclose(
+                        speed_np,
+                        speed_jax,
+                        rtol=1e-5,
+                        atol=1e-5,
+                        err_msg=f"Speed doesn't match for q1={q1}, q2={q2}, dt={dt}",
+                    )
+                    np.testing.assert_allclose(
+                        np.abs(axis_np),
+                        np.abs(axis_jax),
+                        rtol=1e-5,
+                        atol=1e-5,
+                        err_msg=f"Axis doesn't match for q1={q1}, q2={q2}, dt={dt}",
+                    )
+
+                    # For dt=1.0, also check against expected results
+                    if dt == 1.0:
+                        np.testing.assert_allclose(
+                            speed_jax,
+                            expected_speed,
+                            rtol=1e-5,
+                            atol=1e-5,
+                            err_msg=f"Speed doesn't match expected for q1={q1}, q2={q2}",
+                        )
+                        np.testing.assert_allclose(
+                            np.abs(axis_jax),
+                            np.abs(expected_axis),
+                            rtol=1e-5,
+                            atol=1e-5,
+                            err_msg=f"Axis doesn't match expected for q1={q1}, q2={q2}",
+                        )
+
+        except Exception as e:
+            print(f"Error in quatDiff2Vel test: {str(e)}")
+            raise
+
+    def test_quatDiff2Vel_properties(self):
+        """Test mathematical properties of quaternion difference to velocity conversion"""
+        try:
+            for q1, q2 in self.diff2vel_test_cases:
+                q1_jax = jp.array(q1, dtype=jp.float32)
+                q2_jax = jp.array(q2, dtype=jp.float32)
+
+                # Property 1: Zero velocity for identical quaternions
+                speed, axis = jax_quatDiff2Vel(q1_jax, q1_jax, dt=1.0)
+                np.testing.assert_allclose(
+                    float(speed),
+                    0.0,
+                    atol=1e-5,
+                    err_msg=f"Non-zero speed for identical quaternions: q={q1}",
+                )
+
+                # Property 2: Scaling with dt
+                speed1, axis1 = jax_quatDiff2Vel(q1_jax, q2_jax, dt=1.0)
+                speed2, axis2 = jax_quatDiff2Vel(q1_jax, q2_jax, dt=2.0)
+                np.testing.assert_allclose(
+                    float(speed1),
+                    2 * float(speed2),
+                    rtol=1e-5,
+                    err_msg=f"Speed scaling with dt failed for q1={q1}, q2={q2}",
+                )
+                np.testing.assert_allclose(
+                    np.abs(np.array(axis1)),
+                    np.abs(np.array(axis2)),
+                    rtol=1e-5,
+                    err_msg=f"Axis changed with dt for q1={q1}, q2={q2}",
+                )
+
+        except Exception as e:
+            print(f"Error in quatDiff2Vel properties test: {str(e)}")
+            raise
+
+    def test_axis_angle2quat_implementations_match(self):
+        """Test that JAX and NumPy implementations of axis_angle2quat give the same results"""
+        try:
+            for (axis, angle), expected_result in zip(
+                self.axis_angle_test_cases, self.axis_angle_expected_results
+            ):
+                # Convert inputs to JAX arrays
+                print(
+                    f"\nTesting axis_angle2quat with inputs: axis={axis}, angle={angle}"
+                )
+                axis_jax = jp.array(axis, dtype=jp.float32)
+
+                # Compute results from both implementations
+                result_np = np_axis_angle2quat(axis, angle)
+                result_jax = jax_axis_angle2quat(axis_jax, angle)
+
+                print(f"NumPy result: {result_np}")
+                print(f"JAX result: {result_jax}")
+                print(f"Expected result: {expected_result}")
+
+                # Convert JAX result to numpy for comparison
+                result_jax = np.array(result_jax)
+
+                # Compare results
+                np.testing.assert_allclose(
+                    np.abs(result_np),
+                    np.abs(result_jax),
+                    rtol=1e-5,
+                    atol=1e-5,
+                    err_msg=f"Results don't match for axis={axis}, angle={angle}",
+                )
+
+                # Compare with expected results
+                np.testing.assert_allclose(
+                    np.abs(result_jax),
+                    np.abs(expected_result),
+                    rtol=1e-5,
+                    atol=1e-5,
+                    err_msg=f"Result doesn't match expected for axis={axis}, angle={angle}",
+                )
+
+        except Exception as e:
+            print(f"Error in axis_angle2quat test: {str(e)}")
+            raise
+
+    def test_euler2mat_implementations_match(self):
+        """Test that JAX and NumPy implementations of euler2mat give the same results"""
+        try:
+            for euler in self.euler_test_cases:
+                # Convert input to JAX array
+                print(f"\nTesting euler2mat with input: euler={euler}")
+                euler_jax = jp.array(euler, dtype=jp.float32)
+
+                # Compute results from both implementations
+                result_np = np_euler2mat(euler)
+                result_jax = jax_euler2mat(euler_jax)
+
+                print(f"NumPy result:\n{result_np}")
+                print(f"JAX result:\n{result_jax}")
+
+                # Convert JAX result to numpy for comparison
+                result_jax = np.array(result_jax)
+
+                # Compare results
+                np.testing.assert_allclose(
+                    result_np,
+                    result_jax,
+                    rtol=1e-5,
+                    atol=1e-5,
+                    err_msg=f"Results don't match for euler={euler}",
+                )
+
+                # Test orthogonality property
+                mat_t = result_jax.T
+                identity = np.eye(3, dtype=np.float32)
+                np.testing.assert_allclose(
+                    result_jax @ mat_t,
+                    identity,
+                    rtol=1e-5,
+                    atol=1e-5,
+                    err_msg=f"Matrix not orthogonal for euler={euler}",
+                )
+
+        except Exception as e:
+            print(f"Error in euler2mat test: {str(e)}")
+            raise
+
+    def test_axis_angle2quat_properties(self):
+        """Test mathematical properties of axis-angle to quaternion conversion"""
+        try:
+            for axis, angle in self.axis_angle_test_cases:
+                axis_jax = jp.array(axis, dtype=jp.float32)
+
+                # Property 1: Result should be a unit quaternion
+                result = jax_axis_angle2quat(axis_jax, angle)
+                norm = jp.sqrt(jp.sum(result * result))
+                np.testing.assert_allclose(
+                    float(norm),
+                    1.0,
+                    rtol=1e-5,
+                    atol=1e-5,
+                    err_msg=f"Result not unit quaternion for axis={axis}, angle={angle}",
+                )
+
+                # Property 2: Zero angle should give identity quaternion
+                result_zero = jax_axis_angle2quat(axis_jax, 0.0)
+                identity = jp.array([1.0, 0.0, 0.0, 0.0], dtype=jp.float32)
+                np.testing.assert_allclose(
+                    np.array(result_zero),
+                    identity,
+                    rtol=1e-5,
+                    atol=1e-5,
+                    err_msg=f"Zero angle doesn't give identity for axis={axis}",
+                )
+
+        except Exception as e:
+            print(f"Error in axis_angle2quat properties test: {str(e)}")
+            raise
+
+    def test_euler2mat_properties(self):
+        """Test mathematical properties of Euler angles to rotation matrix conversion"""
+        try:
+            for euler in self.euler_test_cases:
+                euler_jax = jp.array(euler, dtype=jp.float32)
+
+                # Property 1: Determinant should be 1 (proper rotation)
+                result = jax_euler2mat(euler_jax)
+                det = jp.linalg.det(result)
+                np.testing.assert_allclose(
+                    float(det),
+                    1.0,
+                    rtol=1e-5,
+                    atol=1e-5,
+                    err_msg=f"Determinant not 1 for euler={euler}",
+                )
+
+                # Property 2: Zero angles should give identity matrix
+                zero_euler = jp.zeros(3, dtype=jp.float32)
+                result_zero = jax_euler2mat(zero_euler)
+                identity = jp.eye(3, dtype=jp.float32)
+                np.testing.assert_allclose(
+                    np.array(result_zero),
+                    identity,
+                    rtol=1e-5,
+                    atol=1e-5,
+                    err_msg="Zero angles don't give identity matrix",
+                )
+
+        except Exception as e:
+            print(f"Error in euler2mat properties test: {str(e)}")
+            raise
+
+    def test_mat2euler_implementations_match(self):
+        """Test that JAX and NumPy implementations of mat2euler give the same results"""
+        try:
+            for mat, expected_euler in zip(
+                self.mat2euler_test_cases, self.mat2euler_expected_results
+            ):
+                # Convert input to JAX array
+                print(f"\nTesting mat2euler with input matrix:\n{mat}")
+                mat_jax = jp.array(mat, dtype=jp.float32)
+
+                # Compute results from both implementations
+                result_np = np_mat2euler(mat)
+                result_jax = jax_mat2euler(mat_jax)
+
+                print(f"NumPy result: {result_np}")
+                print(f"JAX result: {result_jax}")
+                print(f"Expected result: {expected_euler}")
+
+                # Convert JAX result to numpy for comparison
+                result_jax = np.array(result_jax)
+
+                # Compare results
+                # Note: We need to handle angle wrapping (e.g., -π and π are equivalent)
+                np.testing.assert_allclose(
+                    np.sin(result_np),
+                    np.sin(result_jax),
+                    rtol=1e-5,
+                    atol=1e-5,
+                    err_msg=f"Results don't match for matrix:\n{mat}",
+                )
+                np.testing.assert_allclose(
+                    np.cos(result_np),
+                    np.cos(result_jax),
+                    rtol=1e-5,
+                    atol=1e-5,
+                    err_msg=f"Results don't match for matrix:\n{mat}",
+                )
+
+                # Compare with expected results
+                np.testing.assert_allclose(
+                    np.sin(result_jax),
+                    np.sin(expected_euler),
+                    rtol=1e-3,
+                    atol=1e-3,
+                    err_msg=f"Result doesn't match expected for matrix:\n{mat}",
+                )
+                np.testing.assert_allclose(
+                    np.cos(result_jax),
+                    np.cos(expected_euler),
+                    rtol=1e-3,
+                    atol=1e-3,
+                    err_msg=f"Result doesn't match expected for matrix:\n{mat}",
+                )
+
+        except Exception as e:
+            print(f"Error in mat2euler test: {str(e)}")
+            raise
+
+    def test_mat2euler_properties(self):
+        """Test mathematical properties of rotation matrix to Euler angles conversion"""
+        try:
+            for mat, expected_euler in zip(
+                self.mat2euler_test_cases, self.mat2euler_expected_results
+            ):
+                mat_jax = jp.array(mat, dtype=jp.float32)
+
+                # Property 1: Converting back to matrix should give original matrix
+                euler = jax_mat2euler(mat_jax)
+                reconstructed_mat = jax_euler2mat(euler)
+                np.testing.assert_allclose(
+                    np.array(reconstructed_mat),
+                    mat,
+                    rtol=1e-3,
+                    atol=1e-3,
+                    err_msg=f"Reconstruction failed for matrix:\n{mat}",
+                )
+
+                # Property 2: Identity matrix should give zero angles
+                if jp.allclose(mat_jax, jp.eye(3)):
+                    np.testing.assert_allclose(
+                        np.array(euler),
+                        np.zeros(3),
+                        rtol=1e-5,
+                        atol=1e-5,
+                        err_msg="Identity matrix doesn't give zero angles",
+                    )
+
+        except Exception as e:
+            print(f"Error in mat2euler properties test: {str(e)}")
+            raise
+
+    def test_mat2quat_implementations_match(self):
+        """Test that JAX and NumPy implementations of mat2quat give the same results"""
+        try:
+            for mat, expected_quat in zip(
+                self.mat2quat_test_cases, self.mat2quat_expected_results
+            ):
+                # Convert input to JAX array
+                print(f"\nTesting mat2quat with input matrix:\n{mat}")
+                mat_jax = jp.array(mat, dtype=jp.float32)
+
+                # Compute results from both implementations
+                result_np = np_mat2quat(mat)
+                result_jax = jax_mat2quat(mat_jax)
+
+                print(f"NumPy result: {result_np}")
+                print(f"JAX result: {result_jax}")
+                print(f"Expected result: {expected_quat}")
+
+                # Convert JAX result to numpy for comparison
+                result_jax = np.array(result_jax)
+
+                # Compare results (using absolute values due to possible sign differences)
+                np.testing.assert_allclose(
+                    np.abs(result_np),
+                    np.abs(result_jax),
+                    rtol=1e-5,
+                    atol=1e-5,
+                    err_msg=f"Results don't match for matrix:\n{mat}",
+                )
+
+                # Compare with expected results
+                np.testing.assert_allclose(
+                    np.abs(result_jax),
+                    np.abs(expected_quat),
+                    rtol=1e-5,
+                    atol=1e-5,
+                    err_msg=f"Result doesn't match expected for matrix:\n{mat}",
+                )
+
+        except Exception as e:
+            print(f"Error in mat2quat test: {str(e)}")
+            raise
+
+    def test_mat2quat_properties(self):
+        """Test mathematical properties of rotation matrix to quaternion conversion"""
+        try:
+            for mat, expected_quat in zip(
+                self.mat2quat_test_cases, self.mat2quat_expected_results
+            ):
+                mat_jax = jp.array(mat, dtype=jp.float32)
+
+                # Property 1: Result should be a unit quaternion
+                result = jax_mat2quat(mat_jax)
+                norm = jp.sqrt(jp.sum(result * result))
+                np.testing.assert_allclose(
+                    float(norm),
+                    1.0,
+                    rtol=1e-5,
+                    atol=1e-5,
+                    err_msg=f"Result not unit quaternion for matrix:\n{mat}",
+                )
+
+                # Property 2: Identity matrix should give identity quaternion
+                if jp.allclose(mat_jax, jp.eye(3)):
+                    identity_quat = jp.array([1.0, 0.0, 0.0, 0.0], dtype=jp.float32)
+                    np.testing.assert_allclose(
+                        np.abs(np.array(result)),
+                        np.abs(identity_quat),
+                        rtol=1e-5,
+                        atol=1e-5,
+                        err_msg="Identity matrix doesn't give identity quaternion",
+                    )
+
+                # Property 3: Converting back to matrix should give original matrix
+                quat = jax_mat2quat(mat_jax)
+                reconstructed_mat = jax_quat2mat(quat)
+                np.testing.assert_allclose(
+                    np.array(reconstructed_mat),
+                    mat,
+                    rtol=1e-4,
+                    atol=1e-4,
+                    err_msg=f"Reconstruction failed for matrix:\n{mat}",
+                )
+
+        except Exception as e:
+            print(f"Error in mat2quat properties test: {str(e)}")
+            raise
+
+    def test_quat2euler_implementations_match(self):
+        """Test that JAX and NumPy implementations of quat2euler give the same results"""
+        try:
+            for quat, expected_euler in zip(
+                self.quat2euler_test_cases, self.quat2euler_expected_results
+            ):
+                # Convert input to JAX array
+                print(f"\nTesting quat2euler with input quaternion: {quat}")
+                quat_jax = jp.array(quat, dtype=jp.float32)
+
+                # Compute results from both implementations
+                result_np = np_quat2euler(quat)
+                result_jax = jax_quat2euler(quat_jax)
+
+                print(f"NumPy result: {result_np}")
+                print(f"JAX result: {result_jax}")
+                print(f"Expected result: {expected_euler}")
+
+                # Convert JAX result to numpy for comparison
+                result_jax = np.array(result_jax)
+
+                # Compare results (using sin/cos to handle angle wrapping)
+                np.testing.assert_allclose(
+                    np.sin(result_np),
+                    np.sin(result_jax),
+                    rtol=1e-5,
+                    atol=1e-5,
+                    err_msg=f"Results don't match for quaternion: {quat}",
+                )
+                np.testing.assert_allclose(
+                    np.cos(result_np),
+                    np.cos(result_jax),
+                    rtol=1e-5,
+                    atol=1e-5,
+                    err_msg=f"Results don't match for quaternion: {quat}",
+                )
+
+                # Compare with expected results
+                np.testing.assert_allclose(
+                    np.sin(result_jax),
+                    np.sin(expected_euler),
+                    rtol=1e-3,
+                    atol=1e-3,
+                    err_msg=f"Result doesn't match expected for quaternion: {quat}",
+                )
+                np.testing.assert_allclose(
+                    np.cos(result_jax),
+                    np.cos(expected_euler),
+                    rtol=1e-3,
+                    atol=1e-3,
+                    err_msg=f"Result doesn't match expected for quaternion: {quat}",
+                )
+
+        except Exception as e:
+            print(f"Error in quat2euler test: {str(e)}")
+            raise
+
+    def test_quat2euler_properties(self):
+        """Test mathematical properties of quaternion to Euler angles conversion"""
+        try:
+            for quat, expected_euler in zip(
+                self.quat2euler_test_cases, self.quat2euler_expected_results
+            ):
+                quat_jax = jp.array(quat, dtype=jp.float32)
+
+                # Property 1: Converting back to quaternion should give original quaternion
+                euler = jax_quat2euler(quat_jax)
+                reconstructed_quat = jax_euler2quat(euler)
+
+                # Compare quaternions (using absolute values due to possible sign differences)
+                np.testing.assert_allclose(
+                    np.abs(np.array(reconstructed_quat)),
+                    np.abs(quat),
+                    rtol=1e-3,
+                    atol=1e-3,
+                    err_msg=f"Reconstruction failed for quaternion: {quat}",
+                )
+
+                # Property 2: Identity quaternion should give zero angles
+                if jp.allclose(quat_jax, jp.array([1.0, 0.0, 0.0, 0.0])):
+                    np.testing.assert_allclose(
+                        np.array(euler),
+                        np.zeros(3),
+                        rtol=1e-5,
+                        atol=1e-5,
+                        err_msg="Identity quaternion doesn't give zero angles",
+                    )
+
+        except Exception as e:
+            print(f"Error in quat2euler properties test: {str(e)}")
+            raise
+
+    def test_quat2mat_implementations_match(self):
+        """Test that JAX and NumPy implementations of quat2mat give the same results"""
+        try:
+            for quat, expected_mat in zip(
+                self.quat2mat_test_cases, self.quat2mat_expected_results
+            ):
+                # Convert input to JAX array
+                print(f"\nTesting quat2mat with input quaternion: {quat}")
+                quat_jax = jp.array(quat, dtype=jp.float32)
+
+                # Compute results from both implementations
+                result_np = np_quat2mat(quat)
+                result_jax = jax_quat2mat(quat_jax)
+
+                print(f"NumPy result:\n{result_np}")
+                print(f"JAX result:\n{result_jax}")
+                print(f"Expected result:\n{expected_mat}")
+
+                # Convert JAX result to numpy for comparison
+                result_jax = np.array(result_jax)
+
+                # Compare results
+                np.testing.assert_allclose(
+                    result_np,
+                    result_jax,
+                    rtol=1e-5,
+                    atol=1e-5,
+                    err_msg=f"Results don't match for quaternion: {quat}",
+                )
+
+                # Compare with expected results
+                np.testing.assert_allclose(
+                    result_jax,
+                    expected_mat,
+                    rtol=1e-3,
+                    atol=1e-3,
+                    err_msg=f"Result doesn't match expected for quaternion: {quat}",
+                )
+
+        except Exception as e:
+            print(f"Error in quat2mat test: {str(e)}")
+            raise
+
+    def test_quat2mat_properties(self):
+        """Test mathematical properties of quaternion to rotation matrix conversion"""
+        try:
+            for quat, expected_mat in zip(
+                self.quat2mat_test_cases, self.quat2mat_expected_results
+            ):
+                quat_jax = jp.array(quat, dtype=jp.float32)
+
+                # Property 1: Result should be orthogonal (R * R^T = I)
+                result = jax_quat2mat(quat_jax)
+                result_t = jp.transpose(result)
+                identity = jp.eye(3, dtype=jp.float32)
+                np.testing.assert_allclose(
+                    np.array(result @ result_t),
+                    identity,
+                    rtol=1e-5,
+                    atol=1e-5,
+                    err_msg=f"Matrix not orthogonal for quaternion: {quat}",
+                )
+
+                # Property 2: Determinant should be 1 (proper rotation)
+                det = jp.linalg.det(result)
+                np.testing.assert_allclose(
+                    float(det),
+                    1.0,
+                    rtol=1e-5,
+                    atol=1e-5,
+                    err_msg=f"Determinant not 1 for quaternion: {quat}",
+                )
+
+                # Property 3: Identity quaternion should give identity matrix
+                if jp.allclose(quat_jax, jp.array([1.0, 0.0, 0.0, 0.0])):
+                    np.testing.assert_allclose(
+                        np.array(result),
+                        identity,
+                        rtol=1e-5,
+                        atol=1e-5,
+                        err_msg="Identity quaternion doesn't give identity matrix",
+                    )
+
+                # Property 4: Converting back to quaternion should give original quaternion
+                reconstructed_quat = jax_mat2quat(result)
+                np.testing.assert_allclose(
+                    np.abs(np.array(reconstructed_quat)),
+                    np.abs(quat),
+                    rtol=1e-4,
+                    atol=1e-4,
+                    err_msg=f"Reconstruction failed for quaternion: {quat}",
+                )
+
+        except Exception as e:
+            print(f"Error in quat2mat properties test: {str(e)}")
+            raise
+
+    def test_rotVecMatT_implementations_match(self):
+        """Test that JAX and NumPy implementations of rotVecMatT give the same results"""
+        try:
+            for (vec, mat), expected_result in zip(
+                self.rotVecMatT_test_cases, self.rotVecMatT_expected_results
+            ):
+                # Convert inputs to JAX arrays
+                print(f"\nTesting rotVecMatT with inputs:\nvec={vec}\nmat=\n{mat}")
+                vec_jax = jp.array(vec, dtype=jp.float32)
+                mat_jax = jp.array(mat, dtype=jp.float32)
+
+                # Compute results from both implementations
+                result_np = np_rotVecMatT(vec, mat)
+                result_jax = jax_rotVecMatT(vec_jax, mat_jax)
+
+                print(f"NumPy result: {result_np}")
+                print(f"JAX result: {result_jax}")
+                print(f"Expected result: {expected_result}")
+
+                # Convert JAX result to numpy for comparison
+                result_jax = np.array(result_jax)
+
+                # Compare results
+                np.testing.assert_allclose(
+                    result_np,
+                    result_jax,
+                    rtol=1e-5,
+                    atol=1e-5,
+                    err_msg=f"Results don't match for vec={vec}, mat=\n{mat}",
+                )
+
+                # Compare with expected results
+                np.testing.assert_allclose(
+                    result_jax,
+                    expected_result,
+                    rtol=1e-4,
+                    atol=1e-4,
+                    err_msg=f"Result doesn't match expected for vec={vec}, mat=\n{mat}",
+                )
+
+        except Exception as e:
+            print(f"Error in rotVecMatT test: {str(e)}")
+            raise
+
+    def test_rotVecMatT_properties(self):
+        """Test mathematical properties of vector rotation by matrix transpose"""
+        try:
+            for (vec, mat), expected_result in zip(
+                self.rotVecMatT_test_cases, self.rotVecMatT_expected_results
+            ):
+                vec_jax = jp.array(vec, dtype=jp.float32)
+                mat_jax = jp.array(mat, dtype=jp.float32)
+
+                # Property 1: Length preservation
+                result = jax_rotVecMatT(vec_jax, mat_jax)
+                orig_length = jp.sqrt(jp.sum(vec_jax * vec_jax))
+                result_length = jp.sqrt(jp.sum(result * result))
+                np.testing.assert_allclose(
+                    float(result_length),
+                    float(orig_length),
+                    rtol=1e-5,
+                    atol=1e-5,
+                    err_msg=f"Length not preserved for vec={vec}, mat=\n{mat}",
+                )
+
+                # Property 2: Identity matrix should not change the vector
+                if jp.allclose(mat_jax, jp.eye(3)):
+                    np.testing.assert_allclose(
+                        np.array(result),
+                        vec,
+                        rtol=1e-5,
+                        atol=1e-5,
+                        err_msg="Identity matrix changed the vector",
+                    )
+
+                # Property 3: Double rotation by mat and mat.T should give original vector
+                # First rotate by mat.T, then by mat
+                intermediate = jax_rotVecMatT(vec_jax, mat_jax)
+                final = jax_rotVecMat(intermediate, mat_jax)
+                np.testing.assert_allclose(
+                    np.array(final),
+                    vec,
+                    rtol=1e-4,
+                    atol=1e-4,
+                    err_msg=f"Double rotation failed for vec={vec}, mat=\n{mat}",
+                )
+
+        except Exception as e:
+            print(f"Error in rotVecMatT properties test: {str(e)}")
+            raise
+
+    def test_rotVecMat_implementations_match(self):
+        """Test that JAX and NumPy implementations of rotVecMat give the same results"""
+        try:
+            for (vec, mat), expected_result in zip(
+                self.rotVecMat_test_cases, self.rotVecMat_expected_results
+            ):
+                # Convert inputs to JAX arrays
+                print(f"\nTesting rotVecMat with inputs:\nvec={vec}\nmat=\n{mat}")
+                vec_jax = jp.array(vec, dtype=jp.float32)
+                mat_jax = jp.array(mat, dtype=jp.float32)
+
+                # Compute results from both implementations
+                result_np = np_rotVecMat(vec, mat)
+                result_jax = jax_rotVecMat(vec_jax, mat_jax)
+
+                print(f"NumPy result: {result_np}")
+                print(f"JAX result: {result_jax}")
+                print(f"Expected result: {expected_result}")
+
+                # Convert JAX result to numpy for comparison
+                result_jax = np.array(result_jax)
+
+                # Compare results
+                np.testing.assert_allclose(
+                    result_np,
+                    result_jax,
+                    rtol=1e-5,
+                    atol=1e-5,
+                    err_msg=f"Results don't match for vec={vec}, mat=\n{mat}",
+                )
+
+                # Compare with expected results
+                np.testing.assert_allclose(
+                    result_jax,
+                    expected_result,
+                    rtol=1e-4,
+                    atol=1e-4,
+                    err_msg=f"Result doesn't match expected for vec={vec}, mat=\n{mat}",
+                )
+
+        except Exception as e:
+            print(f"Error in rotVecMat test: {str(e)}")
+            raise
+
+    def test_rotVecQuat_implementations_match(self):
+        """Test that JAX and NumPy implementations of rotVecQuat give the same results"""
+        try:
+            for (vec, quat), expected_result in zip(
+                self.rotVecQuat_test_cases, self.rotVecQuat_expected_results
+            ):
+                # Convert inputs to JAX arrays
+                print(f"\nTesting rotVecQuat with inputs:\nvec={vec}\nquat={quat}")
+                vec_jax = jp.array(vec, dtype=jp.float32)
+                quat_jax = jp.array(quat, dtype=jp.float32)
+
+                # Compute results from both implementations
+                result_np = np_rotVecQuat(vec, quat)
+                result_jax = jax_rotVecQuat(vec_jax, quat_jax)
+
+                print(f"NumPy result: {result_np}")
+                print(f"JAX result: {result_jax}")
+                print(f"Expected result: {expected_result}")
+
+                # Convert JAX result to numpy for comparison
+                result_jax = np.array(result_jax)
+
+                # Compare results
+                np.testing.assert_allclose(
+                    result_np,
+                    result_jax,
+                    rtol=1e-5,
+                    atol=1e-5,
+                    err_msg=f"Results don't match for vec={vec}, quat={quat}",
+                )
+
+                # Compare with expected results
+                np.testing.assert_allclose(
+                    result_jax,
+                    expected_result,
+                    rtol=1e-4,
+                    atol=1e-4,
+                    err_msg=f"Result doesn't match expected for vec={vec}, quat={quat}",
+                )
+
+        except Exception as e:
+            print(f"Error in rotVecQuat test: {str(e)}")
+            raise
+
+    def test_rotation_properties(self):
+        """Test mathematical properties of vector rotations"""
+        try:
+            # Test that rotVecQuat gives same results as rotVecMat with equivalent rotation
+            for (vec, quat), expected_result in zip(
+                self.rotVecQuat_test_cases, self.rotVecQuat_expected_results
+            ):
+                vec_jax = jp.array(vec, dtype=jp.float32)
+                quat_jax = jp.array(quat, dtype=jp.float32)
+
+                # Convert quaternion to matrix
+                mat_jax = jax_quat2mat(quat_jax)
+
+                # Rotate vector using both methods
+                result_quat = jax_rotVecQuat(vec_jax, quat_jax)
+                result_mat = jax_rotVecMat(vec_jax, mat_jax)
+
+                # Results should match
+                np.testing.assert_allclose(
+                    np.array(result_quat),
+                    np.array(result_mat),
+                    rtol=1e-4,
+                    atol=1e-4,
+                    err_msg=f"Quaternion and matrix rotations don't match for vec={vec}",
+                )
+
+                # Length preservation
+                orig_length = jp.sqrt(jp.sum(vec_jax * vec_jax))
+                result_length = jp.sqrt(jp.sum(result_quat * result_quat))
+                np.testing.assert_allclose(
+                    float(result_length),
+                    float(orig_length),
+                    rtol=1e-5,
+                    atol=1e-5,
+                    err_msg=f"Length not preserved for vec={vec}",
+                )
+
+                # Identity rotation should not change vector
+                if jp.allclose(quat_jax, jp.array([1.0, 0.0, 0.0, 0.0])):
+                    np.testing.assert_allclose(
+                        np.array(result_quat),
+                        vec,
+                        rtol=1e-5,
+                        atol=1e-5,
+                        err_msg="Identity rotation changed the vector",
+                    )
+
+        except Exception as e:
+            print(f"Error in rotation properties test: {str(e)}")
+            raise
+
+    def test_quat2euler_intrinsic_implementations_match(self):
+        """Test that JAX and NumPy implementations of quat2euler_intrinsic give the same results"""
+        try:
+            for quat, expected_euler in zip(
+                self.quat2euler_intrinsic_test_cases,
+                self.quat2euler_intrinsic_expected_results,
+            ):
+                # Convert input to JAX array
+                print(f"\nTesting quat2euler_intrinsic with input quaternion: {quat}")
+                quat_jax = jp.array(quat, dtype=jp.float32)
+
+                # Compute results from both implementations
+                result_np = np_quat2euler_intrinsic(quat)
+                result_jax = jax_quat2euler_intrinsic(quat_jax)
+
+                print(f"NumPy result: {result_np}")
+                print(f"JAX result: {result_jax}")
+                print(f"Expected result: {expected_euler}")
+
+                # Convert JAX result to numpy for comparison
+                result_jax = np.array(result_jax)
+
+                # Compare results (using sin/cos to handle angle wrapping)
+                np.testing.assert_allclose(
+                    np.sin(result_np),
+                    np.sin(result_jax),
+                    rtol=1e-5,
+                    atol=1e-5,
+                    err_msg=f"Results don't match for quaternion: {quat}",
+                )
+                np.testing.assert_allclose(
+                    np.cos(result_np),
+                    np.cos(result_jax),
+                    rtol=1e-5,
+                    atol=1e-5,
+                    err_msg=f"Results don't match for quaternion: {quat}",
+                )
+
+                # Compare with expected results
+                np.testing.assert_allclose(
+                    np.sin(result_jax),
+                    np.sin(expected_euler),
+                    rtol=1e-4,
+                    atol=1e-4,
+                    err_msg=f"Result doesn't match expected for quaternion: {quat}",
+                )
+                np.testing.assert_allclose(
+                    np.cos(result_jax),
+                    np.cos(expected_euler),
+                    rtol=1e-4,
+                    atol=1e-4,
+                    err_msg=f"Result doesn't match expected for quaternion: {quat}",
+                )
+
+        except Exception as e:
+            print(f"Error in quat2euler_intrinsic test: {str(e)}")
+            raise
+
+    def test_quat2euler_intrinsic_properties(self):
+        """Test mathematical properties of quaternion to intrinsic Euler angles conversion"""
+        try:
+            for quat, expected_euler in zip(
+                self.quat2euler_intrinsic_test_cases,
+                self.quat2euler_intrinsic_expected_results,
+            ):
+                quat_jax = jp.array(quat, dtype=jp.float32)
+
+                # Property 1: Converting back to quaternion should give original quaternion
+                euler = jax_quat2euler_intrinsic(quat_jax)
+                reconstructed_quat = jax_euler2quat(euler)
+
+                # Compare quaternions (using absolute values due to possible sign differences)
+                np.testing.assert_allclose(
+                    np.abs(np.array(reconstructed_quat)),
+                    np.abs(quat),
+                    rtol=1e-3,
+                    atol=1e-3,
+                    err_msg=f"Reconstruction failed for quaternion: {quat}",
+                )
+
+                # Property 2: Identity quaternion should give zero angles
+                if jp.allclose(quat_jax, jp.array([1.0, 0.0, 0.0, 0.0])):
+                    np.testing.assert_allclose(
+                        np.array(euler),
+                        np.zeros(3),
+                        rtol=1e-5,
+                        atol=1e-5,
+                        err_msg="Identity quaternion doesn't give zero angles",
+                    )
+
+                # Property 3: Angles should be in valid ranges
+                euler_np = np.array(euler)
+                self.assertTrue(
+                    np.all(euler_np >= -np.pi) and np.all(euler_np <= np.pi),
+                    f"Euler angles out of range [-π, π] for quaternion: {quat}",
+                )
+
+        except Exception as e:
+            print(f"Error in quat2euler_intrinsic properties test: {str(e)}")
+            raise
+
+    def test_euler2quat_implementations_match(self):
+        """Test that JAX and NumPy implementations of intrinsic_euler2quat give the same results"""
+        try:
+            for euler, expected_quat in zip(
+                self.euler2quat_test_cases, self.euler2quat_expected_results
+            ):
+                # Convert input to JAX array
+                print(f"\nTesting euler2quat with input Euler angles: {euler}")
+                euler_jax = jp.array(euler, dtype=jp.float32)
+
+                # Compute results from both implementations
+                result_np = np_euler2quat(euler)
+                result_jax = jax_euler2quat(euler_jax)
+
+                print(f"NumPy result: {result_np}")
+                print(f"JAX result: {result_jax}")
+                print(f"Expected result: {expected_quat}")
+
+                # Convert JAX result to numpy for comparison
+                result_jax = np.array(result_jax)
+
+                # Compare results (using absolute values due to possible sign differences)
+                np.testing.assert_allclose(
+                    np.abs(result_np),
+                    np.abs(result_jax),
+                    rtol=1e-5,
+                    atol=1e-5,
+                    err_msg=f"Results don't match for Euler angles: {euler}",
+                )
+
+                # Compare with expected results
+                np.testing.assert_allclose(
+                    np.abs(result_jax),
+                    np.abs(expected_quat),
+                    rtol=1e-4,
+                    atol=1e-4,
+                    err_msg=f"Result doesn't match expected for Euler angles: {euler}",
+                )
+
+        except Exception as e:
+            print(f"Error in euler2quat test: {str(e)}")
+            raise
+
+    def test_euler2quat_properties(self):
+        """Test mathematical properties of Euler angles to quaternion conversion"""
+        try:
+            for euler, expected_quat in zip(
+                self.euler2quat_test_cases, self.euler2quat_expected_results
+            ):
+                euler_jax = jp.array(euler, dtype=jp.float32)
+
+                # Property 1: Result should be a unit quaternion
+                result = jax_euler2quat(euler_jax)
+                norm = jp.sqrt(jp.sum(result * result))
+                np.testing.assert_allclose(
+                    float(norm),
+                    1.0,
+                    rtol=1e-5,
+                    atol=1e-5,
+                    err_msg=f"Result not unit quaternion for Euler angles: {euler}",
+                )
+
+                # Property 2: Zero angles should give identity quaternion
+                if jp.allclose(euler_jax, jp.zeros(3)):
+                    identity_quat = jp.array([1.0, 0.0, 0.0, 0.0], dtype=jp.float32)
+                    np.testing.assert_allclose(
+                        np.abs(np.array(result)),
+                        np.abs(identity_quat),
+                        rtol=1e-5,
+                        atol=1e-5,
+                        err_msg="Zero angles don't give identity quaternion",
+                    )
+
+                # Property 3: Converting back to Euler angles should give original angles
+                reconstructed_euler = jax_quat2euler_intrinsic(result)
+                np.testing.assert_allclose(
+                    np.sin(np.array(reconstructed_euler)),
+                    np.sin(euler),
+                    rtol=1e-3,
+                    atol=1e-3,
+                    err_msg=f"Reconstruction failed for Euler angles: {euler}",
+                )
+                print(f"Reconstructed euler: {reconstructed_euler}")
+                print(f"Euler: {euler}")
+                np.testing.assert_allclose(
+                    np.cos(np.array(reconstructed_euler)),
+                    np.cos(euler),
+                    rtol=1e-3,
+                    atol=1e-3,
+                    err_msg=f"Reconstruction failed for Euler angles: {euler}",
+                )
+
+        except Exception as e:
+            print(f"Error in euler2quat properties test: {str(e)}")
+            raise
+
+
+if __name__ == "__main__":
+    try:
+        unittest.main()
+    except Exception as e:
+        print(f"Test failed with error: {str(e)}")

--- a/myosuite/tests/mjx/test_reference_motion.py
+++ b/myosuite/tests/mjx/test_reference_motion.py
@@ -1,0 +1,459 @@
+import unittest
+import numpy as np
+import glob
+
+from myosuite.logger.reference_motion_jax import ReferenceMotion as JaxReferenceMotion
+from myosuite.logger.reference_motion import ReferenceMotion as NumpyReferenceMotion
+from myosuite.logger.reference_motion import ReferenceType
+
+
+class TestReferenceMotion(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # Path to test data
+        cls.data_dir = "./myosuite/envs/myo/myodm/data/"
+        cls.reference_files = glob.glob(f"{cls.data_dir}*.npz")
+        cls.ignore_files = [
+            f"{cls.data_dir}MyoHand_cylindersmall_lift.npz",
+            f"{cls.data_dir}MyoHand_fryingpan_cook2.npz",
+            f"{cls.data_dir}MyoHand_hand_pass1.npz",
+            f"{cls.data_dir}MyoHand_knife_lift.npz",
+            f"{cls.data_dir}MyoHand_wineglass_drink1.npz",
+        ]
+        cls.fixed_ref_data = {
+            "time": (0.0, 4.0),
+            "robot": np.zeros((1, 29)),
+            "robot_vel": np.zeros((1, 29)),
+            "object_init": np.array((0.0, 0.0, 0.1, 1.0, 0.0, 0.0, 0.0)),
+            "object": np.array([[-0.2, -0.2, 0.1, 1.0, 0.0, 0.0, -1.0]]),
+        }
+
+        cls.random_ref_data = {
+            "time": (0.0, 4.0),
+            "robot": np.zeros((2, 29)),
+            "robot_vel": np.zeros((2, 29)),
+            "object_init": np.array((0.0, 0.0, 0.1, 1.0, 0.0, 0.0, 0.0)),
+            "object": np.array(
+                [
+                    [-0.2, -0.2, 0.1, 1.0, 0.0, 0.0, -1.0],
+                    [0.2, 0.2, 0.1, 1.0, 0.0, 0.0, 1.0],
+                ]
+            ),
+        }
+        cls.file_path = "./myosuite/envs/myo/myodm/data/MyoHand_airplane_fly1.npz"
+
+    def test_load_npz_file(self):
+        """Test loading .npz files in both implementations"""
+        for file_path in self.reference_files:
+            if file_path in self.ignore_files:
+                print(f"Skipping {file_path} because it is in the ignore list")
+                continue
+
+            # Load with both implementations
+            numpy_ref = NumpyReferenceMotion(file_path)
+            jax_ref = JaxReferenceMotion(file_path)
+
+            # Compare basic properties
+            self.assertEqual(jax_ref.horizon, numpy_ref.horizon)
+            self.assertEqual(jax_ref.robot_dim, numpy_ref.robot_dim)
+            self.assertEqual(jax_ref.object_dim, numpy_ref.object_dim)
+            self.assertEqual(jax_ref.type.value, numpy_ref.type.value)
+
+            # Compare reference data
+            np.testing.assert_allclose(
+                np.array(jax_ref.reference["time"]),
+                numpy_ref.reference["time"],
+                rtol=1e-5,
+            )
+            if jax_ref.reference["robot"] is not None:
+                np.testing.assert_allclose(
+                    np.array(jax_ref.reference["robot"]),
+                    numpy_ref.reference["robot"],
+                    rtol=1e-5,
+                )
+            if jax_ref.reference["object"] is not None:
+                np.testing.assert_allclose(
+                    np.array(jax_ref.reference["object"]),
+                    numpy_ref.reference["object"],
+                    rtol=1e-5,
+                )
+
+    def test_fixed_reference(self):
+        """Test fixed reference type in both implementations"""
+        # Create references
+
+        jax_ref = JaxReferenceMotion(self.fixed_ref_data)
+        numpy_ref = NumpyReferenceMotion(self.fixed_ref_data)
+
+        # Check type
+        self.assertEqual(jax_ref.type.value, ReferenceType.FIXED.value)
+        self.assertEqual(numpy_ref.type.value, ReferenceType.FIXED.value)
+
+        # Check initialization
+        robot_init_jax, object_init_jax = jax_ref.get_init()
+        robot_init_numpy, object_init_numpy = numpy_ref.get_init()
+
+        np.testing.assert_allclose(np.array(robot_init_jax), robot_init_numpy)
+        np.testing.assert_allclose(np.array(object_init_jax), object_init_numpy)
+
+    def test_random_reference(self):
+        """Test random reference type in both implementations"""
+        # Create references
+        jax_ref = JaxReferenceMotion(self.random_ref_data)
+        numpy_ref = NumpyReferenceMotion(self.random_ref_data)
+
+        # Check type
+        self.assertEqual(jax_ref.type.value, ReferenceType.RANDOM.value)
+        self.assertEqual(numpy_ref.type.value, ReferenceType.RANDOM.value)
+
+        # Check initialization
+        robot_init_jax, object_init_jax = jax_ref.get_init()
+        robot_init_numpy, object_init_numpy = numpy_ref.get_init()
+
+        np.testing.assert_allclose(np.array(robot_init_jax), robot_init_numpy)
+        np.testing.assert_allclose(np.array(object_init_jax), object_init_numpy)
+
+    def test_track_reference(self):
+        """Test tracking reference type using actual motion files"""
+
+        # Create references
+        jax_ref = JaxReferenceMotion(self.file_path)
+        numpy_ref = NumpyReferenceMotion(self.file_path)
+
+        # Check type
+        self.assertEqual(jax_ref.type.value, ReferenceType.TRACK.value)
+        self.assertEqual(numpy_ref.type.value, ReferenceType.TRACK.value)
+
+        # Test time slot finding
+        test_times = [0.0, 0.1, 0.5, 1.0]
+        for time in test_times:
+            jax_indices = jax_ref.find_timeslot_in_reference(time)
+            numpy_indices = numpy_ref.find_timeslot_in_reference(time)
+            self.assertEqual(jax_indices, numpy_indices)
+
+    def test_reset(self):
+        """Test reset functionality"""
+
+        # Create references
+        jax_ref = JaxReferenceMotion(self.file_path)
+        numpy_ref = NumpyReferenceMotion(self.file_path)
+
+        # Advance index cache
+        _ = jax_ref.find_timeslot_in_reference(0.5)
+        _ = numpy_ref.find_timeslot_in_reference(0.5)
+
+        # Reset
+        jax_ref.reset()
+        numpy_ref.reset()
+
+        # Check if index cache is reset
+        self.assertEqual(jax_ref.index_cache, 0)
+        self.assertEqual(numpy_ref.index_cache, 0)
+
+    def test_error_handling(self):
+        """Test error handling in both implementations"""
+        # Test invalid reference data
+        invalid_ref = {
+            "time": np.array([0.0]),
+            "robot": np.array([0.0, 0.1, 0.2]),  # Wrong shape
+        }
+
+        with self.assertRaises(AssertionError):
+            _ = JaxReferenceMotion(invalid_ref)
+        with self.assertRaises(AssertionError):
+            _ = NumpyReferenceMotion(invalid_ref)
+
+        # Test missing time key
+        invalid_ref = {"robot": np.array([[0.0, 0.1, 0.2]])}
+
+        with self.assertRaises(AssertionError):
+            _ = JaxReferenceMotion(invalid_ref)
+        with self.assertRaises(AssertionError):
+            _ = NumpyReferenceMotion(invalid_ref)
+
+    def test_get_init_fixed(self):
+        """Test get_init for fixed reference type"""
+        jax_ref = JaxReferenceMotion(self.fixed_ref_data)
+        numpy_ref = NumpyReferenceMotion(self.fixed_ref_data)
+
+        # Get initial states
+        jax_robot_init, jax_object_init = jax_ref.get_init()
+        numpy_robot_init, numpy_object_init = numpy_ref.get_init()
+
+        # Compare results
+        np.testing.assert_allclose(
+            np.array(jax_robot_init),
+            numpy_robot_init,
+            rtol=1e-5,
+            err_msg="Robot init states don't match",
+        )
+        np.testing.assert_allclose(
+            np.array(jax_object_init),
+            numpy_object_init,
+            rtol=1e-5,
+            err_msg="Object init states don't match",
+        )
+
+    def test_get_init_random(self):
+        """Test get_init for random reference type"""
+        jax_ref = JaxReferenceMotion(self.random_ref_data)
+        numpy_ref = NumpyReferenceMotion(self.random_ref_data)
+
+        # Get initial states
+        jax_robot_init, jax_object_init = jax_ref.get_init()
+        numpy_robot_init, numpy_object_init = numpy_ref.get_init()
+
+        np.testing.assert_allclose(
+            np.array(jax_robot_init),
+            numpy_robot_init,
+            rtol=1e-5,
+            err_msg="Robot init states don't match",
+        )
+        np.testing.assert_allclose(
+            np.array(jax_object_init),
+            numpy_object_init,
+            rtol=1e-5,
+            err_msg="Object init states don't match",
+        )
+
+    def test_get_reference_fixed(self):
+        """Test get_reference for fixed reference type"""
+        jax_ref = JaxReferenceMotion(self.fixed_ref_data)
+        numpy_ref = NumpyReferenceMotion(self.fixed_ref_data)
+
+        # Test at different times (should all give same result for fixed type)
+        test_times = [0.0, 0.5, 1.0]
+
+        for time in test_times:
+            jax_ref_struct = jax_ref.get_reference(time)
+            numpy_ref_struct = numpy_ref.get_reference(time)
+
+            # Compare results
+            np.testing.assert_allclose(
+                np.array(jax_ref_struct.robot),
+                numpy_ref_struct.robot,
+                rtol=1e-5,
+                err_msg=f"Robot refs don't match at time {time}",
+            )
+            np.testing.assert_allclose(
+                np.array(jax_ref_struct.object),
+                numpy_ref_struct.object,
+                rtol=1e-5,
+                err_msg=f"Object refs don't match at time {time}",
+            )
+
+    def test_get_reference_track(self):
+        """Test get_reference for tracking reference type"""
+        jax_ref = JaxReferenceMotion(self.file_path)
+        numpy_ref = NumpyReferenceMotion(self.file_path)
+
+        # Test exact timestamps
+        time = jax_ref.reference["time"][1]  # Use second timestamp
+        jax_ref_struct = jax_ref.get_reference(time)
+        numpy_ref_struct = numpy_ref.get_reference(time)
+
+        # Compare results at exact timestamp
+        np.testing.assert_allclose(
+            np.array(jax_ref_struct.robot),
+            numpy_ref_struct.robot,
+            rtol=1e-5,
+            err_msg="Robot refs don't match at exact timestamp",
+        )
+
+        # Test interpolation
+        time = (jax_ref.reference["time"][1] + jax_ref.reference["time"][2]) / 2
+        jax_ref_struct = jax_ref.get_reference(time)
+        numpy_ref_struct = numpy_ref.get_reference(time)
+
+        # Compare interpolated results
+        np.testing.assert_allclose(
+            np.array(jax_ref_struct.robot),
+            numpy_ref_struct.robot,
+            rtol=1e-5,
+            err_msg="Robot refs don't match during interpolation",
+        )
+
+    def test_get_reference_extrapolation(self):
+        """Test get_reference with extrapolation"""
+        # Enable extrapolation
+        jax_ref = JaxReferenceMotion(self.file_path, motion_extrapolation=True)
+        numpy_ref = NumpyReferenceMotion(self.file_path, motion_extrapolation=True)
+
+        # Test beyond final timestamp
+        max_time = jax_ref.reference["time"][-1]
+        test_time = max_time + 1.0
+
+        jax_ref_struct = jax_ref.get_reference(test_time)
+        numpy_ref_struct = numpy_ref.get_reference(test_time)
+
+        # Compare extrapolated results
+        np.testing.assert_allclose(
+            np.array(jax_ref_struct.robot),
+            numpy_ref_struct.robot,
+            rtol=1e-5,
+            err_msg="Robot refs don't match during extrapolation",
+        )
+
+        # Should match final position when extrapolating
+        np.testing.assert_allclose(
+            np.array(jax_ref_struct.robot),
+            jax_ref.reference["robot"][-1],
+            rtol=1e-5,
+            err_msg="Extrapolation doesn't match final position",
+        )
+        
+    def test_missing_init_fixed(self):
+        """Test initialization when robot_init and object_init are missing for fixed reference"""
+        # Create reference data without init values
+        fixed_ref_no_init = {
+            "time": np.array([0.0]),
+            "robot": np.array([[1.0, 2.0, 3.0]]),
+            "robot_vel": np.array([[0.1, 0.2, 0.3]]),
+            "object": np.array([[4.0, 5.0, 6.0]]),
+        }
+
+        # Create references
+        jax_ref = JaxReferenceMotion(fixed_ref_no_init)
+        numpy_ref = NumpyReferenceMotion(fixed_ref_no_init)
+
+        # Get initial states
+        jax_robot_init, jax_object_init = jax_ref.get_init()
+        numpy_robot_init, numpy_object_init = numpy_ref.get_init()
+
+        # For fixed type, init should be first frame
+        expected_robot_init = fixed_ref_no_init["robot"][0]
+        expected_object_init = fixed_ref_no_init["object"][0]
+
+        # Compare results
+        np.testing.assert_allclose(
+            np.array(jax_robot_init),
+            expected_robot_init,
+            rtol=1e-5,
+            err_msg="Robot init not using first frame",
+        )
+        np.testing.assert_allclose(
+            np.array(jax_object_init),
+            expected_object_init,
+            rtol=1e-5,
+            err_msg="Object init not using first frame",
+        )
+
+        # Compare JAX and NumPy implementations
+        np.testing.assert_allclose(
+            np.array(jax_robot_init),
+            numpy_robot_init,
+            rtol=1e-5,
+            err_msg="Robot init states don't match between implementations",
+        )
+        np.testing.assert_allclose(
+            np.array(jax_object_init),
+            numpy_object_init,
+            rtol=1e-5,
+            err_msg="Object init states don't match between implementations",
+        )
+
+    def test_missing_init_random(self):
+        """Test initialization when robot_init and object_init are missing for random reference"""
+        # Create reference data without init values
+        random_ref_no_init = {
+            "time": np.array([0.0, 1.0]),
+            "robot": np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]),
+            "robot_vel": np.array([[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]),
+            "object": np.array([[7.0, 8.0, 9.0], [10.0, 11.0, 12.0]]),
+        }
+
+        # Create references
+        jax_ref = JaxReferenceMotion(random_ref_no_init)
+        numpy_ref = NumpyReferenceMotion(random_ref_no_init)
+
+        # Get initial states
+        jax_robot_init, jax_object_init = jax_ref.get_init()
+        numpy_robot_init, numpy_object_init = numpy_ref.get_init()
+
+        # For random type, init should be mean of bounds
+        expected_robot_init = random_ref_no_init["robot"][0]
+        expected_object_init = random_ref_no_init["object"][0]
+
+        # Compare results with expected means
+        np.testing.assert_allclose(
+            np.array(jax_robot_init),
+            expected_robot_init,
+            rtol=1e-5,
+            err_msg="Robot init not using mean of bounds",
+        )
+        np.testing.assert_allclose(
+            np.array(jax_object_init),
+            expected_object_init,
+            rtol=1e-5,
+            err_msg="Object init not using mean of bounds",
+        )
+
+        # Compare JAX and NumPy implementations
+        np.testing.assert_allclose(
+            np.array(jax_robot_init),
+            numpy_robot_init,
+            rtol=1e-5,
+            err_msg="Robot init states don't match between implementations",
+        )
+        np.testing.assert_allclose(
+            np.array(jax_object_init),
+            numpy_object_init,
+            rtol=1e-5,
+            err_msg="Object init states don't match between implementations",
+        )
+
+    def test_missing_init_track(self):
+        """Test initialization when robot_init and object_init are missing for track reference"""
+        # Load tracking data
+        track_ref = {k: v for k, v in np.load(self.file_path).items()}
+
+        # Remove init values if they exist
+        track_ref.pop("robot_init", None)
+        track_ref.pop("object_init", None)
+
+        # Create references
+        jax_ref = JaxReferenceMotion(track_ref)
+        numpy_ref = NumpyReferenceMotion(track_ref)
+
+        # Get initial states
+        jax_robot_init, jax_object_init = jax_ref.get_init()
+        numpy_robot_init, numpy_object_init = numpy_ref.get_init()
+
+        # For track type, init should be first frame
+        expected_robot_init = track_ref["robot"][0] if "robot" in track_ref else None
+        expected_object_init = track_ref["object"][0] if "object" in track_ref else None
+
+        # Compare results with first frame
+        if expected_robot_init is not None:
+            np.testing.assert_allclose(
+                np.array(jax_robot_init),
+                expected_robot_init,
+                rtol=1e-5,
+                err_msg="Robot init not using first frame",
+            )
+        if expected_object_init is not None:
+            np.testing.assert_allclose(
+                np.array(jax_object_init),
+                expected_object_init,
+                rtol=1e-5,
+                err_msg="Object init not using first frame",
+            )
+
+        # Compare JAX and NumPy implementations
+        np.testing.assert_allclose(
+            np.array(jax_robot_init),
+            numpy_robot_init,
+            rtol=1e-5,
+            err_msg="Robot init states don't match between implementations",
+        )
+        if jax_object_init is not None and numpy_object_init is not None:
+            np.testing.assert_allclose(
+                np.array(jax_object_init),
+                numpy_object_init,
+                rtol=1e-5,
+                err_msg="Object init states don't match between implementations",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/myosuite/utils/quat_math_jax.py
+++ b/myosuite/utils/quat_math_jax.py
@@ -1,0 +1,254 @@
+import jax.numpy as jp
+import jax
+
+# Constants for floating-point precision
+_FLOAT_EPS = jp.finfo(jp.float32).eps
+_EPS4 = _FLOAT_EPS * 4.0
+
+
+def mulQuat(qa, qb):
+    res = jp.zeros(4)
+    res = res.at[0].set(qa[0] * qb[0] - qa[1] * qb[1] - qa[2] * qb[2] - qa[3] * qb[3])
+    res = res.at[1].set(qa[0] * qb[1] + qa[1] * qb[0] + qa[2] * qb[3] - qa[3] * qb[2])
+    res = res.at[2].set(qa[0] * qb[2] - qa[1] * qb[3] + qa[2] * qb[0] + qa[3] * qb[1])
+    res = res.at[3].set(qa[0] * qb[3] + qa[1] * qb[2] - qa[2] * qb[1] + qa[3] * qb[0])
+    return res
+
+
+def negQuat(quat):
+    return jp.array([quat[0], -quat[1], -quat[2], -quat[3]])
+
+
+def quat2Vel(quat, dt=1):
+    axis = quat[1:].copy()
+    sin_a_2 = jp.sqrt(jp.sum(axis**2))
+    axis = axis / (sin_a_2 + 1e-8)
+    speed = 2 * jp.arctan2(sin_a_2, quat[0]) / dt
+    return speed, axis
+
+
+def diffQuat(quat1, quat2):
+    neg = negQuat(quat1)
+    return mulQuat(quat2, neg)
+
+
+def quatDiff2Vel(quat1, quat2, dt):
+    diff = diffQuat(quat1, quat2)
+    return quat2Vel(diff, dt)
+
+
+def axis_angle2quat(axis, angle):
+    c = jp.cos(angle / 2)
+    s = jp.sin(angle / 2)
+    return jp.array([c, s * axis[0], s * axis[1], s * axis[2]])
+
+
+def euler2mat(euler):
+    euler = jp.asarray(euler, dtype=jp.float32)
+    ai, aj, ak = -euler[..., 2], -euler[..., 1], -euler[..., 0]
+    si, sj, sk = jp.sin(ai), jp.sin(aj), jp.sin(ak)
+    ci, cj, ck = jp.cos(ai), jp.cos(aj), jp.cos(ak)
+    cc, cs = ci * ck, ci * sk
+    sc, ss = si * ck, si * sk
+
+    mat = jp.empty(euler.shape[:-1] + (3, 3), dtype=jp.float32)
+    mat = mat.at[..., 2, 2].set(cj * ck)
+    mat = mat.at[..., 2, 1].set(sj * sc - cs)
+    mat = mat.at[..., 2, 0].set(sj * cc + ss)
+    mat = mat.at[..., 1, 2].set(cj * sk)
+    mat = mat.at[..., 1, 1].set(sj * ss + cc)
+    mat = mat.at[..., 1, 0].set(sj * cs - sc)
+    mat = mat.at[..., 0, 2].set(-sj)
+    mat = mat.at[..., 0, 1].set(cj * si)
+    mat = mat.at[..., 0, 0].set(cj * ci)
+    return mat
+
+
+def euler2quat(euler):
+    euler = jp.asarray(euler, dtype=jp.float32)
+    ai, aj, ak = euler[..., 2] / 2, -euler[..., 1] / 2, euler[..., 0] / 2
+    si, sj, sk = jp.sin(ai), jp.sin(aj), jp.sin(ak)
+    ci, cj, ck = jp.cos(ai), jp.cos(aj), jp.cos(ak)
+    cc, cs = ci * ck, ci * sk
+    sc, ss = si * ck, si * sk
+
+    quat = jp.empty(euler.shape[:-1] + (4,), dtype=jp.float32)
+    quat = quat.at[..., 0].set(cj * cc + sj * ss)
+    quat = quat.at[..., 3].set(cj * sc - sj * cs)
+    quat = quat.at[..., 2].set(-(cj * ss + sj * cc))
+    quat = quat.at[..., 1].set(cj * cs - sj * sc)
+    return quat
+
+
+def mat2euler(mat):
+    mat = jp.asarray(mat, dtype=jp.float32)
+    cy = jp.sqrt(mat[..., 2, 2] * mat[..., 2, 2] + mat[..., 1, 2] * mat[..., 1, 2])
+    condition = cy > _EPS4
+    euler = jp.empty(mat.shape[:-2] + (3,), dtype=jp.float32)
+    euler = euler.at[..., 2].set(
+        jp.where(
+            condition,
+            -jp.arctan2(mat[..., 0, 1], mat[..., 0, 0]),
+            -jp.arctan2(-mat[..., 1, 0], mat[..., 1, 1]),
+        )
+    )
+    euler = euler.at[..., 1].set(
+        jp.where(
+            condition,
+            -jp.arctan2(-mat[..., 0, 2], cy),
+            -jp.arctan2(-mat[..., 0, 2], cy),
+        )
+    )
+    euler = euler.at[..., 0].set(
+        jp.where(condition, -jp.arctan2(mat[..., 1, 2], mat[..., 2, 2]), 0.0)
+    )
+    return euler
+
+
+def mat2quat(mat):
+    """Convert Rotation Matrix to Quaternion using JAX"""
+    mat = jp.asarray(mat, dtype=jp.float32)
+    assert mat.shape == (3, 3), f"Invalid shape matrix {mat.shape}"
+
+    def case_1(mat):
+        trace = 1.0 + mat[0, 0] - mat[1, 1] - mat[2, 2]
+        s = 2.0 * jp.sqrt(trace)
+        s = jp.where(mat[1, 2] < mat[2, 1], -s, s)
+        q1 = 0.25 * s
+        s = 1.0 / s
+        q0 = (mat[1, 2] - mat[2, 1]) * s
+        q2 = (mat[0, 1] + mat[1, 0]) * s
+        q3 = (mat[2, 0] + mat[0, 2]) * s
+        return jp.array([q0, q1, q2, q3])
+
+    def case_2(mat):
+        trace = 1.0 - mat[0, 0] + mat[1, 1] - mat[2, 2]
+        s = 2.0 * jp.sqrt(trace)
+        s = jp.where(mat[2, 0] < mat[0, 2], -s, s)
+        q2 = 0.25 * s
+        s = 1.0 / s
+        q0 = (mat[2, 0] - mat[0, 2]) * s
+        q1 = (mat[0, 1] + mat[1, 0]) * s
+        q3 = (mat[1, 2] + mat[2, 1]) * s
+        return jp.array([q0, q1, q2, q3])
+
+    def case_3(mat):
+        trace = 1.0 - mat[0, 0] - mat[1, 1] + mat[2, 2]
+        s = 2.0 * jp.sqrt(trace)
+        s = jp.where(mat[0, 1] < mat[1, 0], -s, s)
+        q3 = 0.25 * s
+        s = 1.0 / s
+        q0 = (mat[0, 1] - mat[1, 0]) * s
+        q1 = (mat[2, 0] + mat[0, 2]) * s
+        q2 = (mat[1, 2] + mat[2, 1]) * s
+        return jp.array([q0, q1, q2, q3])
+
+    def case_4(mat):
+        trace = 1.0 + mat[0, 0] + mat[1, 1] + mat[2, 2]
+        s = 2.0 * jp.sqrt(trace)
+        q0 = 0.25 * s
+        s = 1.0 / s
+        q1 = (mat[1, 2] - mat[2, 1]) * s
+        q2 = (mat[2, 0] - mat[0, 2]) * s
+        q3 = (mat[0, 1] - mat[1, 0]) * s
+        return jp.array([q0, q1, q2, q3])
+
+    # Conditional execution for efficiency
+    q = jax.lax.cond(
+        mat[2, 2] < 0.0,
+        lambda mat: jax.lax.cond(mat[0, 0] > mat[1, 1], case_1, case_2, mat),
+        lambda mat: jax.lax.cond(mat[0, 0] < -mat[1, 1], case_3, case_4, mat),
+        mat,
+    )
+
+    q = q.at[1:].set(-q[1:])
+    return q
+
+
+def quat2euler(quat):
+    return mat2euler(quat2mat(quat))
+
+
+def quat2mat(quat):
+    quat = jp.asarray(quat, dtype=jp.float32)
+    w, x, y, z = quat[..., 0], quat[..., 1], quat[..., 2], quat[..., 3]
+    Nq = jp.sum(quat * quat, axis=-1)
+    s = 2.0 / Nq
+    X, Y, Z = x * s, y * s, z * s
+    wX, wY, wZ = w * X, w * Y, w * Z
+    xX, xY, xZ = x * X, x * Y, x * Z
+    yY, yZ, zZ = y * Y, y * Z, z * Z
+
+    mat = jp.empty(quat.shape[:-1] + (3, 3), dtype=jp.float32)
+    mat = mat.at[..., 0, 0].set(1.0 - (yY + zZ))
+    mat = mat.at[..., 0, 1].set(xY - wZ)
+    mat = mat.at[..., 0, 2].set(xZ + wY)
+    mat = mat.at[..., 1, 0].set(xY + wZ)
+    mat = mat.at[..., 1, 1].set(1.0 - (xX + zZ))
+    mat = mat.at[..., 1, 2].set(yZ - wX)
+    mat = mat.at[..., 2, 0].set(xZ - wY)
+    mat = mat.at[..., 2, 1].set(yZ + wX)
+    mat = mat.at[..., 2, 2].set(1.0 - (xX + yY))
+    return jp.where((Nq > _FLOAT_EPS)[..., jp.newaxis, jp.newaxis], mat, jp.eye(3))
+
+
+def rotVecMatT(vec, mat):
+    return jp.array(
+        [
+            mat[0, 0] * vec[0] + mat[1, 0] * vec[1] + mat[2, 0] * vec[2],
+            mat[0, 1] * vec[0] + mat[1, 1] * vec[1] + mat[2, 1] * vec[2],
+            mat[0, 2] * vec[0] + mat[1, 2] * vec[1] + mat[2, 2] * vec[2],
+        ]
+    )
+
+
+def rotVecMat(vec, mat):
+    return jp.array(
+        [
+            mat[0, 0] * vec[0] + mat[0, 1] * vec[1] + mat[0, 2] * vec[2],
+            mat[1, 0] * vec[0] + mat[1, 1] * vec[1] + mat[1, 2] * vec[2],
+            mat[2, 0] * vec[0] + mat[2, 1] * vec[1] + mat[2, 2] * vec[2],
+        ]
+    )
+
+
+def rotVecQuat(vec, quat):
+    mat = quat2mat(quat)
+    return rotVecMat(vec, mat)
+
+
+def quat2euler_intrinsic(quat):
+    w, x, y, z = quat
+    sinr_cosp = 2 * (w * x + y * z)
+    cosr_cosp = 1 - 2 * (x * x + y * y)
+    roll = jp.arctan2(sinr_cosp, cosr_cosp)
+
+    sinp = 2 * (w * y - z * x)
+    pitch = jp.where(jp.abs(sinp) >= 1, jp.copysign(jp.pi / 2, sinp), jp.arcsin(sinp))
+
+    siny_cosp = 2 * (w * z + x * y)
+    cosy_cosp = 1 - 2 * (y * y + z * z)
+    yaw = jp.arctan2(siny_cosp, cosy_cosp)
+
+    return jp.array([roll, pitch, yaw])
+
+
+def intrinsic_euler2quat(euler):
+    roll, pitch, yaw = euler
+    half_roll = roll * 0.5
+    half_pitch = pitch * 0.5
+    half_yaw = yaw * 0.5
+
+    sin_roll = jp.sin(half_roll)
+    cos_roll = jp.cos(half_roll)
+    sin_pitch = jp.sin(half_pitch)
+    cos_pitch = jp.cos(half_pitch)
+    sin_yaw = jp.sin(half_yaw)
+    cos_yaw = jp.cos(half_yaw)
+
+    w = cos_roll * cos_pitch * cos_yaw + sin_roll * sin_pitch * sin_yaw
+    x = sin_roll * cos_pitch * cos_yaw - cos_roll * sin_pitch * sin_yaw
+    y = cos_roll * sin_pitch * cos_yaw + sin_roll * cos_pitch * sin_yaw
+    z = cos_roll * cos_pitch * sin_yaw - sin_roll * sin_pitch * cos_yaw
+
+    return jp.array([w, x, y, z])


### PR DESCRIPTION
# Summary
This PR adds JAX‑based helper scripts to MyoSuite with full parity to existing non‑JAX implementations.
The goal is to enable JAX acceleration and differentiable computation while preserving identical behavior.

## Changes
- myosuite/envs/myo/fatigue_jax.py – Fatigue modeling in JAX.

- myosuite/logger/reference_motion_jax.py – Reference motion logging in JAX.

- myosuite/utils/quat_math_jax.py – Quaternion math utilities in JAX.

## Testing

Added tests to confirm exact output match between JAX and non‑JAX versions for all three modules.

## Motivation
- Prepare MyoSuite for JAX‑based RL and optimization workflows.
- Leverage JIT compilation and vectorized ops for speedup.