### PR TITLE
Checkout add_issue_automation branch in workflow

### DIFF
--- a/.github/workflows/issue-analyzer.yml
+++ b/.github/workflows/issue-analyzer.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: add_issue_automation
 
       - name: Set up Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
GitHub Actions only triggers issues/workflow_dispatch events from the default branch (main). This change makes the workflow explicitly checkout the add_issue_automation branch where the scripts live, so only the workflow file itself needs to be on main.

https://claude.ai/code/session_01LZ3oEb365JLANfCA64KC99