### PR TITLE
feat: mjlab backend for BoxingP0 task

### DIFF
--- a/myosuite/envs/myo/backends/mjlab/boxing_mjlab_env.py
+++ b/myosuite/envs/myo/backends/mjlab/boxing_mjlab_env.py
@@ -1,0 +1,278 @@
+# Copyright (c) MyoSuite Authors. All rights reserved.
+#
+# This source code is licensed under the Apache 2 license found in the
+# LICENSE file in the root directory of this source tree.
+"""mjlab bridge functions for the BoxingP0 task (6-pad static target variant).
+
+All observations, rewards, and terminations delegate to the existing CPU-parity
+term functions in ``boxing_mannequin_obs.py`` and ``boxing_mannequin_reward.py``.
+No env subclassing — this module only provides thin bridge callables and a
+``BoxingTaskState`` ManagerTermBase that holds cached MuJoCo ids.
+"""
+
+from __future__ import annotations
+
+from dataclasses import fields as dataclass_fields
+from typing import TYPE_CHECKING, Any
+
+import torch
+from mjlab.managers import ManagerTermBase
+from mjlab.managers.event_manager import requires_model_fields
+
+if TYPE_CHECKING:
+    pass
+
+_BOXING_ENTITY_NAME = "boxing_p0_robot"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _wp_tensor(array: Any, device: str) -> torch.Tensor:
+    return torch.as_tensor(array, device=device)
+
+
+try:
+    from mjlab.envs.mdp.events import resolve_env_ids as _normalize_env_ids
+except ImportError:
+    # mjlab<1.4: resolve_env_ids not yet exported
+    def _normalize_env_ids(env: Any, env_ids: Any) -> torch.Tensor:  # type: ignore[misc]
+        if env_ids is None:
+            return torch.arange(env.num_envs, device=env.device, dtype=torch.long)
+        if isinstance(env_ids, slice):
+            return torch.arange(env.num_envs, device=env.device, dtype=torch.long)[
+                env_ids
+            ]
+        return torch.as_tensor(env_ids, device=env.device, dtype=torch.long).reshape(-1)
+
+
+# ---------------------------------------------------------------------------
+# Task state holder
+# ---------------------------------------------------------------------------
+
+
+class BoxingTaskState(ManagerTermBase):
+    """Holds per-env cached ids for the boxing task.
+
+    Stored on ``env._boxing_state`` so bridge callables can retrieve it.
+    The mannequin (agent_1) is static in P0 — its joints are kept at zero
+    via position actuators already in the model; no extra drive is needed.
+    """
+
+    def __init__(self, cfg: Any, env: Any) -> None:
+        super().__init__(env)
+        self.cfg = cfg
+        self.env = env
+        env._boxing_state = self  # noqa: SLF001
+
+        self.task_cfg = cfg.params["task_cfg"]
+        self.meta = cfg.params["meta"]
+        self.mj_model = cfg.params["mj_model"]
+
+    def __call__(self, env: Any, env_ids: Any, **_: Any) -> None:
+        """Step event hook — no per-step logic needed for static P0 mannequin."""
+
+
+# ---------------------------------------------------------------------------
+# Accessors
+# ---------------------------------------------------------------------------
+
+
+def _get_boxing_state(env: Any) -> BoxingTaskState:
+    state = getattr(env, "_boxing_state", None)
+    if state is None:
+        raise RuntimeError(
+            "BoxingTaskState was not initialized. "
+            "Ensure the step event is registered with mode='step'."
+        )
+    return state
+
+
+def _boxing_mj_data(env: Any) -> Any:
+    """Return a MjData-compatible view populated from the current Warp simulation."""
+    return env.sim.mj_data
+
+
+def _boxing_mj_model(env: Any) -> Any:
+    return env.sim.mj_model
+
+
+# ---------------------------------------------------------------------------
+# Observation bridge functions
+# ---------------------------------------------------------------------------
+
+
+def _boxing_kinematics_obs(env: Any, **_: Any) -> torch.Tensor:
+    """Own joint positions, velocities, and muscle activations. Shape: (N, d)."""
+    from myosuite.terms.multiplayer.boxing_mannequin_obs import own_kinematics_obs
+
+    state = _get_boxing_state(env)
+    arr = own_kinematics_obs(
+        _boxing_mj_model(env),
+        _boxing_mj_data(env),
+        state.meta,
+        "agent_0",
+    )
+    t = torch.as_tensor(arr, device=env.device, dtype=torch.float32).unsqueeze(0)
+    return t.expand(env.num_envs, -1)
+
+
+def _boxing_fist_obs(env: Any, **_: Any) -> torch.Tensor:
+    """Fist positions and velocities. Shape: (N, d)."""
+    from myosuite.terms.multiplayer.boxing_mannequin_obs import own_fist_obs
+
+    state = _get_boxing_state(env)
+    arr = own_fist_obs(_boxing_mj_data(env), state.meta, "agent_0")
+    t = torch.as_tensor(arr, device=env.device, dtype=torch.float32).unsqueeze(0)
+    return t.expand(env.num_envs, -1)
+
+
+def _boxing_pelvis_obs(env: Any, **_: Any) -> torch.Tensor:
+    """Pelvis position and velocity. Shape: (N, d)."""
+    from myosuite.terms.multiplayer.boxing_mannequin_obs import own_pelvis_obs
+
+    state = _get_boxing_state(env)
+    arr = own_pelvis_obs(_boxing_mj_data(env), state.meta, "agent_0")
+    t = torch.as_tensor(arr, device=env.device, dtype=torch.float32).unsqueeze(0)
+    return t.expand(env.num_envs, -1)
+
+
+def _boxing_target_pad_obs(env: Any, **_: Any) -> torch.Tensor:
+    """6-pad position, normal, force, and hit-flag observations. Shape: (N, 48)."""
+    from myosuite.terms.multiplayer.boxing_mannequin_obs import target_pad_obs
+
+    state = _get_boxing_state(env)
+    arr = target_pad_obs(
+        _boxing_mj_model(env),
+        _boxing_mj_data(env),
+        state.meta,
+        "agent_0",
+        hit_force_threshold_n=float(state.task_cfg.target_hit_normal_force_threshold_n),
+    )
+    t = torch.as_tensor(arr, device=env.device, dtype=torch.float32).unsqueeze(0)
+    return t.expand(env.num_envs, -1)
+
+
+def _boxing_health_obs(env: Any, **_: Any) -> torch.Tensor:
+    """Normalised health pair [agent_0, agent_1]. Shape: (N, 2)."""
+    from myosuite.terms.multiplayer.boxing_mannequin_obs import health_obs
+
+    state = _get_boxing_state(env)
+    # P0: static pad variant; no cumulative health tracking in this bridge
+    health: dict[str, float] = {"agent_0": 0.0, "agent_1": 0.0}
+    arr = health_obs(health, "agent_0", float(state.task_cfg.ko_health_threshold))
+    t = torch.as_tensor(arr, device=env.device, dtype=torch.float32).unsqueeze(0)
+    return t.expand(env.num_envs, -1)
+
+
+# ---------------------------------------------------------------------------
+# Reward bridge functions
+# ---------------------------------------------------------------------------
+
+
+def _boxing_pad_damage_reward(env: Any, **_: Any) -> torch.Tensor:
+    """Pad-contact reward using fist contacts. Shape: (N,)."""
+    from myosuite.terms.multiplayer.boxing_mannequin_reward import compute_pad_damage
+
+    state = _get_boxing_state(env)
+    val = compute_pad_damage(
+        _boxing_mj_model(env),
+        _boxing_mj_data(env),
+        state.meta,
+        "agent_0",
+        hit_force_threshold_n=float(state.task_cfg.target_hit_normal_force_threshold_n),
+    )
+    return torch.full(
+        (env.num_envs,), float(val), device=env.device, dtype=torch.float32
+    )
+
+
+def _boxing_upright_posture_reward(env: Any, **_: Any) -> torch.Tensor:
+    """Upright posture reward from pelvis quaternion. Shape: (N,).
+
+    Uses ``1 - 2*(qx^2 + qy^2)`` which equals 1 when the body is perfectly upright.
+    """
+    data = env.sim.wp_data
+    state = _get_boxing_state(env)
+    pelvis_body_id = state.meta.body_ids.get("a0_pelvis")
+    if pelvis_body_id is None:
+        return torch.zeros(env.num_envs, device=env.device, dtype=torch.float32)
+    xquat = _wp_tensor(data.xquat, env.device)  # (N, nbody, 4)
+    q = xquat[:, pelvis_body_id, :]  # (N, 4) in (w, x, y, z) order
+    qx, qy = q[:, 1], q[:, 2]
+    upright = torch.clamp(1.0 - 2.0 * (qx * qx + qy * qy), 0.0, 1.0)
+    return upright
+
+
+def _boxing_act_reg_reward(env: Any, **_: Any) -> torch.Tensor:
+    """Mean-squared action regularization over muscle activations. Shape: (N,).
+
+    Weight should be negative in the env config.
+    """
+    data = env.sim.wp_data
+    act = _wp_tensor(data.act, env.device)  # (N, na)
+    return torch.mean(act * act, dim=1)
+
+
+def _boxing_survival_reward(env: Any, **_: Any) -> torch.Tensor:
+    """Constant survival bonus: 1.0 per step. Shape: (N,)."""
+    return torch.ones(env.num_envs, device=env.device, dtype=torch.float32)
+
+
+# ---------------------------------------------------------------------------
+# Termination bridge
+# ---------------------------------------------------------------------------
+
+
+def _boxing_fall_termination(env: Any, **_: Any) -> torch.Tensor:
+    """Fall termination based on pelvis Z height. Shape: (N,) bool."""
+    from myosuite.terms.multiplayer.boxing_mannequin_reward import is_fallen
+
+    state = _get_boxing_state(env)
+    fell = is_fallen(
+        _boxing_mj_data(env),
+        state.meta,
+        "agent_0",
+        _boxing_config_from_state(state),
+    )
+    return torch.full((env.num_envs,), bool(fell), device=env.device, dtype=torch.bool)
+
+
+def _boxing_config_from_state(state: BoxingTaskState) -> Any:
+    """Reconstruct a ``BoxingMannequinConfig`` from the task config fields."""
+    from myosuite.envs.myo.tasks.challenge.boxing_mannequin.boxing_mannequin_config import (
+        BoxingMannequinConfig,
+    )
+
+    cfg_kwargs = {
+        f.name: getattr(state.task_cfg, f.name)
+        for f in dataclass_fields(BoxingMannequinConfig)
+        if hasattr(state.task_cfg, f.name)
+    }
+    return BoxingMannequinConfig(**cfg_kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Event bridge functions
+# ---------------------------------------------------------------------------
+
+
+@requires_model_fields("qpos0")
+def _boxing_reset_event(env: Any, env_ids: Any, **_: Any) -> None:
+    """Reset boxer entity to default initial state."""
+    env_ids_t = _normalize_env_ids(env, env_ids)
+    if len(env_ids_t) == 0:
+        return
+    entity = env.scene[_BOXING_ENTITY_NAME]
+    entity.reset(env_ids=env_ids_t)
+    env.sim.forward()
+
+
+def _boxing_startup_event(env: Any, env_ids: Any, **_: Any) -> None:
+    """Startup event: reset to initial state."""
+    _boxing_reset_event(env, env_ids)
+
+
+def _boxing_mannequin_pre_physics(env: Any) -> None:
+    """Pre-physics no-op: P0 mannequin is static; position actuators hold joints at zero."""

--- a/myosuite/envs/myo/backends/mjlab/register_mjlab_boxing.py
+++ b/myosuite/envs/myo/backends/mjlab/register_mjlab_boxing.py
@@ -1,0 +1,257 @@
+# Copyright (c) MyoSuite Authors. All rights reserved.
+#
+# This source code is licensed under the Apache 2 license found in the
+# LICENSE file in the root directory of this source tree.
+"""mjlab registration for the BoxingP0 task (myoChallengeBoxingP0Mjlab-v0).
+
+This module owns only registration — env config assembly, mjlab task registration,
+and the public helpers callers use to wire up variants. All env logic (term
+functions, task state, reset events, action classes) lives in boxing_mjlab_env.py.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+try:
+    from myosuite.envs.myo.backends.mjlab.mimic_mjlab_env import (
+        _init_state_from_model,
+        _muscle_tendon_names,
+        _strip_spec_keyframes,
+    )
+except ModuleNotFoundError as _e:
+    raise ModuleNotFoundError(
+        "myosuite mjlab boxing registration requires the 'musclemimic' integration: "
+        "pip install myosuite[musclemimic]"
+    ) from _e
+
+from myosuite.envs.myo.backends.mjlab.mjlab_task_builder import (
+    MyoMuscleActivationActionCfg,
+)
+from myosuite.envs.myo.backends.mjlab.boxing_mjlab_env import (
+    _BOXING_ENTITY_NAME,
+    BoxingTaskState,
+    _boxing_act_reg_reward,
+    _boxing_fall_termination,
+    _boxing_fist_obs,
+    _boxing_health_obs,
+    _boxing_kinematics_obs,
+    _boxing_mannequin_pre_physics,
+    _boxing_pad_damage_reward,
+    _boxing_pelvis_obs,
+    _boxing_reset_event,
+    _boxing_startup_event,
+    _boxing_survival_reward,
+    _boxing_target_pad_obs,
+    _boxing_upright_posture_reward,
+)
+
+BOXING_P0_MJLAB_ENV_ID = "myoChallengeBoxingP0Mjlab-v0"
+
+
+@dataclass
+class BoxingP0MjlabCfg:
+    """Default training hyper-parameters for BoxingP0 mjlab."""
+
+    sim_dt: float = 0.002
+    ctrl_dt: float = 0.01
+    max_episode_steps: int = 500
+    num_envs: int = 256
+
+
+def _build_boxing_boxer_spec_and_model() -> tuple[Any, Any]:
+    """Return ``(mj_model, spec_fn)`` for the boxer-only component of P0.
+
+    We compile the full boxing P0 scene (boxer + static 6-pad machine) to get
+    correct combined ids, then strip keyframes for mjlab.
+    """
+    from myosuite.envs.myo.tasks.challenge.boxing_mannequin.boxing_mannequin_config import (
+        BoxingMannequinConfig,
+    )
+    from myosuite.envs.myo.tasks.challenge.boxing_mannequin.boxing_mannequin_model import (
+        build_boxing_mannequin_model,
+        _build_boxing_mannequin_spec,
+    )
+
+    config = BoxingMannequinConfig(include_boxing_targets_scene=True)
+    mj_model, _, meta = build_boxing_mannequin_model(config)
+
+    def _spec_fn() -> Any:
+        spec = _build_boxing_mannequin_spec(config)
+        _strip_spec_keyframes(spec)
+        return spec
+
+    return mj_model, meta, _spec_fn
+
+
+def _make_boxing_p0_env_cfg(*, play: bool = False) -> Any:
+    """Build the mjlab env config for the BoxingP0 task."""
+    from mjlab.actuator.actuator import TransmissionType
+    from mjlab.envs import ManagerBasedRlEnvCfg
+    from mjlab.envs.mdp import terminations as mdp_terminations
+    from mjlab.entity import EntityArticulationInfoCfg, EntityCfg
+    from mjlab.managers.event_manager import EventTermCfg
+    from mjlab.managers.observation_manager import (
+        ObservationGroupCfg,
+        ObservationTermCfg,
+    )
+    from mjlab.managers.reward_manager import RewardTermCfg
+    from mjlab.managers.termination_manager import TerminationTermCfg
+    from mjlab.scene import SceneCfg
+    from mjlab.sim import MujocoCfg, SimulationCfg
+    from mjlab.viewer import ViewerConfig
+    from myosuite.envs.myo.backends.mjlab.register_mjlab_tasks import (
+        _XmlWrappedActuatorCfg,
+    )
+    from myosuite.envs.myo.tasks.challenge.boxing_mannequin.boxing_mannequin_task_config import (
+        BoxingMannequinTaskConfig,
+    )
+
+    task_cfg = BoxingMannequinTaskConfig(include_boxing_targets_scene=True)
+    mj_model, meta, spec_fn = _build_boxing_boxer_spec_and_model()
+
+    # Muscle tendons from the boxer-only component of the combined model.
+    # We extract tendons from the full combined model (agent_0 prefix = "a0_").
+    # Since _muscle_tendon_names works on the standalone model, we build a
+    # standalone boxer model for tendon extraction.
+    from myosuite.integrations.musclemimic.fullbody_model import (
+        build_mimic_fullbody_spec,
+        default_mimic_fullbody_config,
+    )
+
+    fullbody_cfg = default_mimic_fullbody_config()
+    fullbody_cfg.disable_fingers = task_cfg.disable_fingers
+    fullbody_cfg.sim_dt = task_cfg.sim_dt
+    boxer_spec, _ = build_mimic_fullbody_spec(fullbody_cfg)
+    boxer_model = boxer_spec.compile()
+    tendons = _muscle_tendon_names(boxer_model)
+
+    articulation = EntityArticulationInfoCfg(
+        actuators=(
+            _XmlWrappedActuatorCfg(
+                target_names_expr=tendons,
+                transmission_type=TransmissionType.TENDON,
+            ),
+        )
+    )
+    init_state = _init_state_from_model(boxer_model)
+    robot_entity_cfg = EntityCfg(
+        spec_fn=spec_fn,
+        articulation=articulation,
+        init_state=init_state,
+    )
+
+    hyper = BoxingP0MjlabCfg()
+    scene_cfg = SceneCfg(
+        num_envs=1 if play else hyper.num_envs,
+        entities={_BOXING_ENTITY_NAME: robot_entity_cfg},
+    )
+
+    ctrl_dt = float(task_cfg.ctrl_dt)
+
+    obs_terms: dict[str, Any] = {
+        "kinematics": ObservationTermCfg(func=_boxing_kinematics_obs),
+        "fist": ObservationTermCfg(func=_boxing_fist_obs),
+        "pelvis": ObservationTermCfg(func=_boxing_pelvis_obs),
+        "target_pads": ObservationTermCfg(func=_boxing_target_pad_obs),
+        "health": ObservationTermCfg(func=_boxing_health_obs),
+    }
+    observations = {
+        "policy": ObservationGroupCfg(terms=obs_terms),
+        "actor": ObservationGroupCfg(terms=obs_terms),
+        "critic": ObservationGroupCfg(terms=obs_terms),
+    }
+
+    rewards: dict[str, Any] = {
+        "pad_damage": RewardTermCfg(
+            func=_boxing_pad_damage_reward,
+            weight=0.1 / ctrl_dt,
+        ),
+        "upright_posture": RewardTermCfg(
+            func=_boxing_upright_posture_reward,
+            weight=2.0 / ctrl_dt,
+        ),
+        "act_reg": RewardTermCfg(
+            func=_boxing_act_reg_reward,
+            weight=-0.001 / ctrl_dt,
+        ),
+        "survival": RewardTermCfg(
+            func=_boxing_survival_reward,
+            weight=0.01 / ctrl_dt,
+        ),
+    }
+
+    terminations: dict[str, Any] = {
+        "time_out": TerminationTermCfg(func=mdp_terminations.time_out, time_out=True),
+        "nan_detection": TerminationTermCfg(
+            func=mdp_terminations.nan_detection, time_out=False
+        ),
+        "self_fall": TerminationTermCfg(
+            func=_boxing_fall_termination,
+            time_out=False,
+        ),
+    }
+
+    events: dict[str, Any] = {
+        "boxing_startup": EventTermCfg(
+            func=_boxing_startup_event,
+            mode="startup",
+        ),
+        "boxing_step": EventTermCfg(
+            func=BoxingTaskState,
+            mode="step",
+            params={"task_cfg": task_cfg, "meta": meta, "mj_model": mj_model},
+        ),
+        "boxing_reset": EventTermCfg(
+            func=_boxing_reset_event,
+            mode="reset",
+        ),
+    }
+
+    decimation = max(1, int(round(ctrl_dt / float(task_cfg.sim_dt))))
+
+    return ManagerBasedRlEnvCfg(
+        scene=scene_cfg,
+        decimation=decimation,
+        episode_length_s=float(task_cfg.max_episode_steps) * ctrl_dt,
+        observations=observations,
+        actions={
+            "muscles": MyoMuscleActivationActionCfg(
+                entity_name=_BOXING_ENTITY_NAME,
+                actuator_names=tuple(t.removesuffix("_tendon") for t in tendons),
+                tendon_names=tendons,
+                action_mode="excitation",
+                ctrl_dt=ctrl_dt,
+                pre_physics_fn=_boxing_mannequin_pre_physics,
+            )
+        },
+        rewards=rewards,
+        terminations=terminations,
+        events=events,
+        sim=SimulationCfg(
+            mujoco=MujocoCfg(
+                timestep=float(task_cfg.sim_dt),
+                integrator="euler",
+                ccd_iterations=500,
+            ),
+            njmax=1024,
+            nconmax=1024,
+        ),
+        viewer=ViewerConfig(width=640, height=480),
+        auto_reset=True,
+    )
+
+
+def register_boxing_p0_mjlab_task(
+    register_mjlab_task: Any,
+    rl_cfg_fn: Any,
+) -> None:
+    """Register the BoxingP0 mjlab env with mjlab's task registry."""
+    register_mjlab_task(
+        task_id=BOXING_P0_MJLAB_ENV_ID,
+        env_cfg=_make_boxing_p0_env_cfg(play=False),
+        play_env_cfg=_make_boxing_p0_env_cfg(play=True),
+        rl_cfg=rl_cfg_fn(save_interval=150),
+        runner_cls=None,
+    )

--- a/myosuite/envs/myo/backends/mjlab/register_mjlab_tasks.py
+++ b/myosuite/envs/myo/backends/mjlab/register_mjlab_tasks.py
@@ -48,6 +48,9 @@ from myosuite.envs.myo.backends.mjlab.mimic_mjlab_env import (
 from myosuite.envs.myo.backends.mjlab.register_mjlab_saber import (
     register_saber_p0_mjlab_task,
 )
+from myosuite.envs.myo.backends.mjlab.register_mjlab_boxing import (
+    register_boxing_p0_mjlab_task,
+)
 from myosuite.envs.myo.backends.mjlab.configs.walk_cfg import WalkCfg
 from myosuite.envs.myo.backends.mjlab.register_mjlab_tabletennis import (
     register_table_tennis_mjlab_tasks,
@@ -966,6 +969,19 @@ def register_mjlab_tasks() -> None:
             )
 
     register_table_tennis_mjlab_tasks()
+
+    # --- Boxing P0 ---
+    try:
+        register_boxing_p0_mjlab_task(
+            register_mjlab_task=register_mjlab_task,
+            rl_cfg_fn=default_mimic_clip_on_policy_runner_cfg,
+        )
+    except ValueError:
+        pass  # already registered
+    except Exception:
+        logging.getLogger(__name__).warning(
+            "mjlab: failed to register myoChallengeBoxingP0Mjlab-v0", exc_info=True
+        )
 
 
 def _register_optional_myouser_task(myouser_config: Any) -> None:

--- a/myosuite/envs/myo/tasks/challenge/boxing_mannequin/boxing_task_spec.py
+++ b/myosuite/envs/myo/tasks/challenge/boxing_mannequin/boxing_task_spec.py
@@ -1,0 +1,38 @@
+# Copyright (c) MyoSuite Authors. All rights reserved.
+#
+# This source code is licensed under the Apache 2 license found in the
+# LICENSE file in the root directory of this source tree.
+"""TaskSpec + registration for myoChallengeBoxingP0Mjlab-v0.
+
+Follows the pattern established in ``saber_task_spec.py``.
+"""
+
+from __future__ import annotations
+
+from myosuite.core.registry import register
+from myosuite.core.specs import EnvSpec, TaskSpec
+from myosuite.envs.myo.tasks.challenge.boxing_mannequin.boxing_mannequin_task_config import (
+    BoxingMannequinTaskConfig,
+)
+
+BOXING_P0_MJLAB_ENV_ID = "myoChallengeBoxingP0Mjlab-v0"
+
+
+def get_boxing_p0_task_spec() -> TaskSpec:
+    """Build the task spec for BoxingP0 (6-pad static target variant)."""
+    return TaskSpec(
+        task_config_factory=lambda: BoxingMannequinTaskConfig(
+            include_boxing_targets_scene=True
+        ),
+        backends={"cpu"},
+    )
+
+
+def get_boxing_p0_env_spec() -> EnvSpec:
+    """Build the env spec for BoxingP0."""
+    return EnvSpec(env_id=BOXING_P0_MJLAB_ENV_ID, task_spec=get_boxing_p0_task_spec())
+
+
+def register_boxing_p0_env() -> str:
+    """Register BoxingP0 via EnvSpec adapter path."""
+    return register(get_boxing_p0_env_spec(), wrap_mj_instability_termination=False)

--- a/myosuite/tests/test_boxing_mjlab_registration.py
+++ b/myosuite/tests/test_boxing_mjlab_registration.py
@@ -1,0 +1,60 @@
+# Copyright (c) MyoSuite Authors. All rights reserved.
+#
+# This source code is licensed under the Apache 2 license found in the
+# LICENSE file in the root directory of this source tree.
+"""Smoke tests for the BoxingP0 mjlab backend registration.
+
+If mjlab is not installed, tests are skipped automatically.
+Note: These tests verify that the env cfg builds without error, but do NOT
+instantiate a live ManagerBasedRlEnv (which requires a GPU / Warp runtime).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+mjlab = pytest.importorskip("mjlab", reason="mjlab not installed")
+
+
+def test_boxing_p0_mjlab_cfg_builds() -> None:
+    """Smoke test: the env cfg builds without error."""
+    from myosuite.envs.myo.backends.mjlab.register_mjlab_boxing import (
+        _make_boxing_p0_env_cfg,
+    )
+
+    cfg = _make_boxing_p0_env_cfg(play=False)
+    assert cfg is not None
+
+
+def test_boxing_p0_mjlab_play_cfg_builds() -> None:
+    """Smoke test: the play env cfg builds without error."""
+    from myosuite.envs.myo.backends.mjlab.register_mjlab_boxing import (
+        _make_boxing_p0_env_cfg,
+    )
+
+    cfg = _make_boxing_p0_env_cfg(play=True)
+    assert cfg is not None
+
+
+def test_boxing_p0_mjlab_env_id_constant() -> None:
+    """Ensure the env id constant matches the expected string."""
+    from myosuite.envs.myo.backends.mjlab.register_mjlab_boxing import (
+        BOXING_P0_MJLAB_ENV_ID,
+    )
+
+    assert BOXING_P0_MJLAB_ENV_ID == "myoChallengeBoxingP0Mjlab-v0"
+
+
+def test_boxing_task_spec_imports() -> None:
+    """Smoke test: boxing_task_spec module is importable."""
+    from myosuite.envs.myo.tasks.challenge.boxing_mannequin.boxing_task_spec import (
+        BOXING_P0_MJLAB_ENV_ID,
+        get_boxing_p0_task_spec,
+        get_boxing_p0_env_spec,
+    )
+
+    assert BOXING_P0_MJLAB_ENV_ID == "myoChallengeBoxingP0Mjlab-v0"
+    spec = get_boxing_p0_task_spec()
+    assert spec is not None
+    env_spec = get_boxing_p0_env_spec()
+    assert env_spec is not None


### PR DESCRIPTION
## Summary

- Implements the mjlab backend for `myoChallengeBoxingP0Mjlab-v0` (boxer vs static 6-pad machine, P0 difficulty).
- All obs/reward/termination logic delegates to existing CPU-parity term functions (`boxing_mannequin_obs.py`, `boxing_mannequin_reward.py`) — no duplication.
- No new env subclass; follows the saber mjlab pattern exactly.

### Files added

| File | Purpose |
|---|---|
| `myosuite/envs/myo/backends/mjlab/boxing_mjlab_env.py` | `BoxingTaskState` ManagerTermBase + thin bridge functions |
| `myosuite/envs/myo/backends/mjlab/register_mjlab_boxing.py` | `ManagerBasedRlEnvCfg` assembly + `register_boxing_p0_mjlab_task` |
| `myosuite/envs/myo/tasks/challenge/boxing_mannequin/boxing_task_spec.py` | `TaskSpec` / `EnvSpec` helpers (saber pattern) |
| `myosuite/tests/test_boxing_mjlab_registration.py` | Smoke tests (skipped when mjlab not installed) |

### File modified

- `register_mjlab_tasks.py` — wires up `register_boxing_p0_mjlab_task` so `bootstrap_myosuite_mjlab_registry` registers the boxing task automatically.

## Design decisions

- **Single entity**: Only `agent_0` (boxer) is an mjlab entity with muscle actuators. The static 6-pad machine (agent_1) is part of the same combined model spec; its position actuators hold joints at zero — no extra drive needed.
- **Static mannequin**: `_boxing_mannequin_pre_physics` is a no-op; no scripted attack logic for P0.
- **mj_data bridge**: Obs/reward/termination terms use `env.sim.mj_data` (single-env CPU view) and broadcast to `(num_envs,)` tensors, consistent with the Warp sim pattern.
- **Reward weights** (per task spec): `pad_damage=0.1/ctrl_dt`, `upright_posture=2.0/ctrl_dt`, `act_reg=-0.001/ctrl_dt`, `survival=0.01/ctrl_dt`.

## Test plan

- [x] `pre-commit run --all-files` passes (ruff, ruff-format, pyupgrade, hooks)
- [x] `pytest myosuite/tests/test_boxing_registry.py -v` — 4 passed
- [x] `pytest myosuite/tests/test_model_builder.py myosuite/tests/test_terms_cpu.py myosuite/tests/test_fragment_compat.py -v` — 49 passed, 6 skipped
- [ ] `pytest myosuite/tests/test_boxing_mjlab_registration.py -v` — **skipped** (mjlab not installed in this env; requires GPU / Warp runtime)

> Note: `myosuite/core/muscle_conditions.py` mypy errors are pre-existing and not introduced by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)