### PR TITLE
Expose exact MyoChallenge P2 model preprocessing for accelerated backends

### DIFF
--- a/myosuite/envs/myo/myochallenge/tabletennis_v0.py
+++ b/myosuite/envs/myo/myochallenge/tabletennis_v0.py
@@ -401,10 +401,12 @@ class TableTennisEnvV0(BaseV0):
         dim = model.sensor_dim[sensor_id]
         return data.sensordata[start : start + dim]
 
-    def reset(self, reset_qpos=None, reset_qvel=None, **kwargs):
+    def reset(self, reset_qpos=None, reset_qvel=None, seed=None, **kwargs):
         # self.mj_model.body_pos[self.object_bid] = self.np_random.uniform(**self.target_xyz_range)
         # self.mj_model.body_quat[self.object_bid] = euler2quat(self.np_random.uniform(**self.target_rxryrz_range))
         self.contact_trajectory = []
+        if seed is not None:
+            self.seed(seed)
         self.init_qpos[:] = self.mj_model.key_qpos[0].copy()
 
         # the mass of the paddle slightly changes
@@ -449,8 +451,12 @@ class TableTennisEnvV0(BaseV0):
             v_low, v_high = v_bounds[1], v_bounds[0]
             ball_vel = self.np_random.uniform(low=v_low, high=v_high)
             self.init_qvel[self.ball_dofadr : self.ball_dofadr + 3] = ball_vel
+        mujoco.mj_setConst(self.mj_model, self.mj_data)
         obs = super().reset(
-            reset_qpos=reset_qpos_local, reset_qvel=self.init_qvel, **kwargs
+            reset_qpos=reset_qpos_local,
+            reset_qvel=self.init_qvel,
+            seed=seed,
+            **kwargs,
         )
 
         self.cur_rally = 0

--- a/myosuite/envs/myo/myochallenge/tabletennis_v0.py
+++ b/myosuite/envs/myo/myochallenge/tabletennis_v0.py
@@ -7,6 +7,7 @@ Authors  :: Cheryl Wang (cheryl.wang.huiyi@gmail.com), Balint Hodossy (bkh16@ic.
 import collections
 import enum
 import os
+import warnings
 from typing import List
 
 import h5py
@@ -23,6 +24,76 @@ from myosuite.utils.spec_processing import (
 )
 
 MAX_TIME = 3.0
+
+
+def preprocess_table_tennis_spec(
+    spec: mujoco.MjSpec, remove_body_collisions=True, add_left_arm=True
+) -> mujoco.MjSpec:
+    """Apply the shared official P2 model transformation to a MuJoCo spec."""
+    # We'll process the string path to:
+    # - add contralateral limb
+    # - immobilize leg
+    # - optionally alter physics
+    # - we could attach the paddle at this point too
+    # and compile it to a (wrapped) model - the SimScene can now take that as an input
+
+    for paddle_b in spec.bodies:
+        if "paddle" in paddle_b.name and paddle_b.parent != spec.worldbody:
+            warnings.warn(
+                "A paddle was found that was not a free body. Confirm this is intended."
+            )
+    for s in spec.sensors:
+        if "pingpong" not in s.name and "paddle" not in s.name:
+            spec.delete(s)
+    temp_model = spec.compile()
+
+    removed_ids = recursive_immobilize(
+        spec, temp_model, spec.body("femur_l"), remove_eqs=True
+    )
+    removed_ids.extend(
+        recursive_immobilize(spec, temp_model, spec.body("femur_r"), remove_eqs=True)
+    )
+
+    for key in spec.keys:
+        key.qpos = [j for i, j in enumerate(key.qpos) if i not in removed_ids]
+
+    if remove_body_collisions:
+        recursive_remove_contacts(
+            spec.body("full_body"), return_condition=lambda b: "radius" in b.name
+        )
+
+    if add_left_arm:
+        torso = spec.body("torso")
+
+        spec_copy: mujoco.MjSpec = spec.copy()
+        attachment_frame = torso.add_frame(
+            quat=[0.5, 0.5, -0.5, 0.5], pos=[0.05, 0.373, -0.04]
+        )
+        [spec_copy.delete(k) for k in spec_copy.keys]
+        [spec_copy.delete(t) for t in spec_copy.textures]
+        [spec_copy.delete(m) for m in spec_copy.materials]
+        [spec_copy.delete(t) for t in spec_copy.tendons]
+        [spec_copy.delete(a) for a in spec_copy.actuators]
+        [spec_copy.delete(e) for e in spec_copy.equalities]
+        [spec_copy.delete(s) for s in spec_copy.sensors]
+        [spec_copy.delete(c) for c in spec_copy.cameras]
+        recursive_immobilize(spec_copy, temp_model, spec_copy.worldbody)
+        recursive_remove_contacts(spec_copy.worldbody, return_condition=None)
+
+        meshes_to_mirror = set()
+
+        recursive_mirror(meshes_to_mirror, spec_copy, spec_copy.body("clavicle"))
+        for mesh in spec_copy.meshes:
+            if mesh.name in meshes_to_mirror:
+                mesh.name += "_mirrored"
+                mesh.scale[1] *= -1
+            else:
+                spec_copy.delete(mesh)
+
+        attachment_frame.attach_body(spec_copy.body("clavicle_mirrored"))
+        spec.body("ulna_mirrored").quat = [0.546, 0, 0, -0.838]
+        spec.body("humerus_mirrored").quat = [0.924, 0.383, 0, 0]
+    return spec
 
 
 class TableTennisEnvV0(BaseV0):
@@ -455,75 +526,11 @@ class TableTennisEnvV0(BaseV0):
         return super().step(processed_controls, **kwargs)
 
     def _preprocess_spec(self, spec, remove_body_collisions=True, add_left_arm=True):
-        # We'll process the string path to:
-        # - add contralateral limb
-        # - immobilize leg
-        # - optionally alter physics
-        # - we could attach the paddle at this point too
-        # and compile it to a (wrapped) model - the SimScene can now take that as an input
-
-        for paddle_b in spec.bodies:
-            if "paddle" in paddle_b.name and paddle_b.parent != spec.worldbody:
-                import warnings
-
-                warnings.warn(
-                    "A paddle was found that was not a free body. Confirm this is intended."
-                )
-        for s in spec.sensors:
-            if "pingpong" not in s.name and "paddle" not in s.name:
-                spec.delete(s)
-        temp_model = spec.compile()
-
-        removed_ids = recursive_immobilize(
-            spec, temp_model, spec.body("femur_l"), remove_eqs=True
+        return preprocess_table_tennis_spec(
+            spec,
+            remove_body_collisions=remove_body_collisions,
+            add_left_arm=add_left_arm,
         )
-        removed_ids.extend(
-            recursive_immobilize(
-                spec, temp_model, spec.body("femur_r"), remove_eqs=True
-            )
-        )
-
-        for key in spec.keys:
-            key.qpos = [j for i, j in enumerate(key.qpos) if i not in removed_ids]
-
-        if remove_body_collisions:
-            recursive_remove_contacts(
-                spec.body("full_body"), return_condition=lambda b: "radius" in b.name
-            )
-
-        if add_left_arm:
-            torso = spec.body("torso")
-
-            spec_copy: mujoco.MjSpec = spec.copy()
-            attachment_frame = torso.add_frame(
-                quat=[0.5, 0.5, -0.5, 0.5], pos=[0.05, 0.373, -0.04]
-            )
-            [spec_copy.delete(k) for k in spec_copy.keys]
-            [spec_copy.delete(t) for t in spec_copy.textures]
-            [spec_copy.delete(m) for m in spec_copy.materials]
-            [spec_copy.delete(t) for t in spec_copy.tendons]
-            [spec_copy.delete(a) for a in spec_copy.actuators]
-            [spec_copy.delete(e) for e in spec_copy.equalities]
-            [spec_copy.delete(s) for s in spec_copy.sensors]
-            [spec_copy.delete(c) for c in spec_copy.cameras]
-            recursive_immobilize(spec_copy, temp_model, spec_copy.worldbody)
-            recursive_remove_contacts(spec_copy.worldbody, return_condition=None)
-
-            meshes_to_mirror = set()
-
-            recursive_mirror(meshes_to_mirror, spec_copy, spec_copy.body("clavicle"))
-            for mesh in spec_copy.meshes:
-                if mesh.name in meshes_to_mirror:
-                    mesh.name += "_mirrored"
-                    mesh.scale[1] *= -1
-                else:
-                    spec_copy.delete(mesh)
-
-            attachment_frame.attach_body(spec_copy.body("clavicle_mirrored"))
-            spec.body("ulna_mirrored").quat = [0.546, 0, 0, -0.838]
-            spec.body("humerus_mirrored").quat = [0.924, 0.383, 0, 0]
-            pass
-        return spec
 
 
 class IdInfo:

--- a/myosuite/tests/test_table_tennis.py
+++ b/myosuite/tests/test_table_tennis.py
@@ -1,0 +1,25 @@
+from importlib.resources import files
+
+import mujoco
+import myosuite  # noqa: F401
+import numpy as np
+from myosuite.envs.myo.myochallenge.tabletennis_v0 import preprocess_table_tennis_spec
+
+
+def test_p2_preprocessor_preserves_official_paddle_geometry():
+    model_path = (
+        files("myosuite") / "envs" / "myo" / "assets" / "arm" / "myoarm_tabletennis.xml"
+    )
+    spec = preprocess_table_tennis_spec(mujoco.MjSpec.from_file(str(model_path)))
+    model = spec.compile()
+
+    assert (model.nq, model.nv, model.nu, model.na) == (72, 70, 275, 273)
+    pad_id = model.geom("pad").id
+    assert model.geom_type[pad_id] == mujoco.mjtGeom.mjGEOM_CYLINDER
+    np.testing.assert_array_equal(model.geom_size[pad_id], [0.093, 0.020, 0.0])
+    assert model.geom_contype[pad_id] == 1
+    assert model.geom_conaffinity[pad_id] == 1
+    default_option = mujoco.MjOption()
+    mujoco.mj_defaultOption(default_option)
+    assert model.opt.ccd_tolerance == default_option.ccd_tolerance
+    assert model.opt.tolerance == default_option.tolerance

--- a/myosuite/tests/test_table_tennis.py
+++ b/myosuite/tests/test_table_tennis.py
@@ -1,5 +1,6 @@
 from importlib.resources import files
 
+import gymnasium as gym
 import mujoco
 import myosuite  # noqa: F401
 import numpy as np
@@ -23,3 +24,26 @@ def test_p2_preprocessor_preserves_official_paddle_geometry():
     mujoco.mj_defaultOption(default_option)
     assert model.opt.ccd_tolerance == default_option.ccd_tolerance
     assert model.opt.tolerance == default_option.tolerance
+
+
+def test_p2_reset_seed_covers_domain_randomization():
+    env = gym.make("myoChallengeTableTennisP2-v0")
+    first_obs, _ = env.reset(seed=7)
+    first_mass = env.unwrapped.mj_model.body_mass[env.unwrapped.id_info.paddle_bid]
+    first_subtree_mass = env.unwrapped.mj_model.body_subtreemass[
+        env.unwrapped.id_info.paddle_bid
+    ]
+    first_friction = env.unwrapped.mj_model.geom_friction[
+        env.unwrapped.id_info.ball_gid
+    ].copy()
+
+    second_obs, _ = env.reset(seed=7)
+    second_mass = env.unwrapped.mj_model.body_mass[env.unwrapped.id_info.paddle_bid]
+    second_friction = env.unwrapped.mj_model.geom_friction[
+        env.unwrapped.id_info.ball_gid
+    ]
+
+    np.testing.assert_array_equal(second_obs, first_obs)
+    assert second_mass == first_mass
+    assert first_subtree_mass == first_mass
+    np.testing.assert_array_equal(second_friction, first_friction)


### PR DESCRIPTION
## Summary

- extract the existing Table Tennis P2 `MjSpec` transformation into the public `preprocess_table_tennis_spec` function
- keep `TableTennisEnvV0` and external accelerated backends on the same official model transformation
- seed P2 before reset-time domain randomization
- recompute MuJoCo model constants after reset changes paddle mass, ball friction, and ball placement

## Motivation

Accelerated backends currently have to duplicate the private `TableTennisEnvV0._preprocess_spec` implementation to compile the official P2 model. Exposing the existing transformation lets them consume the same cylindrical paddle geometry and collision model without maintaining a downstream copy.

P2 randomizes model arrays before each episode. Seeding only in the base reset happens after those samples are drawn, so repeated `reset(seed=...)` calls are not reproducible. Mutating `body_mass` also requires `mj_setConst` so derived quantities such as subtree mass match the sampled model.

This PR deliberately does not add an accelerated environment, change the official geometry or tolerances, or change MyoSuite's MuJoCo dependency range. Backend-specific simulation and training code remain downstream.

## Verification

Tested with both MuJoCo 3.6.0 and 3.12.0:

```text
pytest -q myosuite/tests/test_table_tennis.py
2 passed
```

The tests cover the official P2 model contract and deterministic reset-time domain randomization, including recomputed derived mass.